### PR TITLE
Address apt loop deprecation

### DIFF
--- a/tasks/17_packages.yml
+++ b/tasks/17_packages.yml
@@ -15,13 +15,11 @@
   become: 'yes'
   become_method: sudo
   apt:
-    name: "{{ item }}"
+    name: "{{ packages_debian }}"
     state: latest
     install_recommends: 'no'
   environment:
     PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-  with_items:
-    - "{{ packages_debian }}"
   when: ansible_os_family == "Debian"
   tags:
     - apt
@@ -60,11 +58,9 @@
   become: 'yes'
   become_method: sudo
   apt:
-    name: "{{ item }}"
+    name: "{{ packages_blacklist }}"
     state: absent
     purge: 'yes'
-  with_items:
-    - "{{ packages_blacklist }}"
   environment:
     PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
   when: ansible_os_family == "Debian"
@@ -91,12 +87,13 @@
   become: 'yes'
   become_method: sudo
   apt:
-    name: "{{ item }}"
+    name: "{{ packages }}"
     state: latest
     install_recommends: 'no'
-  with_items:
-    - virtualbox-guest-dkms
-    - virtualbox-guest-utils
+  vars:
+    packages:
+      - virtualbox-guest-dkms
+      - virtualbox-guest-utils
   when: ansible_bios_version == "VirtualBox" and ansible_distribution == "Ubuntu"
   tags:
     - apt
@@ -108,11 +105,9 @@
   become: 'yes'
   become_method: sudo
   apt:
-    name: "{{ item }}"
+    name: open-vm-tools
     state: latest
     install_recommends: 'no'
-  with_items:
-    - open-vm-tools
   when: ansible_bios_version == "VMWare"
   tags:
     - apt


### PR DESCRIPTION
When running tasks
- debian family package installation
- debian family package removal
- virtualbox package installation
- vmware package installation

with Ansible 2.7.0 against Ubuntu 18.04, I get:
```
    ubuntu-1804: [DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
    ubuntu-1804: squash_actions is deprecated. Instead of using a loop to supply multiple items
    ubuntu-1804: and specifying `name: {{ item }}`, please use `name: ['{{ packages_debian }}']`
    ubuntu-1804:  and remove the loop. This feature will be removed in version 2.11. Deprecation
    ubuntu-1804:  warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```