### PR TITLE
Ubuntu 18.04  aide 0.16-3

### DIFF
--- a/tasks/24_aide.yml
+++ b/tasks/24_aide.yml
@@ -31,18 +31,37 @@
     - aide
     - security
 
+- name: add aide dir exclusions
+  become: 'yes'
+  blockinfile:
+    path: /etc/aide/aide.conf
+    marker: "# {mark} ANSIBLE MANAGED BLOCK"
+    backup: yes
+    insertafter: EOF
+    block: |
+      !/var/lib/lxcfs
+      !/var/lib/private/systemd
+      !/var/log/journal
+      !/var/log/audit
+
 - name: stat aide.db
   become: 'yes'
   become_method: sudo
   stat:
-    path: /var/lib/aide/aide.db.gz
+    path: /var/lib/aide/aide.db
   register: aidedb
 
 # CCE-27220-3
 - name: initialize aide
   become: 'yes'
   become_method: sudo
-  shell: aide --init -B 'database_out=file:/var/lib/aide/aide.db.gz'
+  expect:
+    command: aideinit
+    timeout: null
+    responses:
+      Question:
+        - 'Overwrite /var/lib/aide/aide.db [yN]?': 'y'
+  shell:
   when: not aidedb.stat.exists
   tags:
     - skip_ansible_lint

--- a/tasks/24_aide.yml
+++ b/tasks/24_aide.yml
@@ -61,7 +61,6 @@
     responses:
       Question:
         - 'Overwrite /var/lib/aide/aide.db [yN]?': 'y'
-  shell:
   when: not aidedb.stat.exists
   tags:
     - skip_ansible_lint


### PR DESCRIPTION
In Ubuntu 18.04 with aide 0.16-3 the default config is as follows:

```
$ sudo cat /etc/aide/aide.conf

# AIDE conf

# The daily cron job depends on these paths
database=file:/var/lib/aide/aide.db
database_out=file:/var/lib/aide/aide.db.new
database_new=file:/var/lib/aide/aide.db.new
gzip_dbout=yes
...
```
In the tasks "stat aide.db" and "initialize aide" the database file expected and created is /var/lib/aide/aide.db.gz

If one manually runs the aidecheck.service.j2 command (/usr/bin/aide.wrapper --check), a message about the lack of a database is shown.

If one stats the database, it is empty.