### PR TITLE
Pip install pexpect if missing

### DIFF
--- a/tasks/01_pre.yml
+++ b/tasks/01_pre.yml
@@ -1,4 +1,9 @@
 ---
+- name: install pexpect
+  become: 'yes'
+  pip:
+    name: pexpect
+
 - name: create custom facts directory
   become: 'yes'
   file:


### PR DESCRIPTION
Otherwise 24_aide.yaml will fail when using the "expect" module