### PR TITLE
Provide prelink remove only if files exists (check modification)

### DIFF
--- a/tasks/prelink.yml
+++ b/tasks/prelink.yml
@@ -21,14 +21,14 @@
     mode: 0644
     state: present
     create: 'yes'
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" and sysconfig_prelink_exists.stat.exists
   tags:
     - prelink
 
 - name: return to non-prelinked state
   become: 'yes'
   command: prelink -ua
-  when: sysconfig_prelink_exists or etc_prelink_exists
+  when: sysconfig_prelink_exists.stat.exists or etc_prelink_exists.stat.exists
   ignore_errors: true
   tags:
     - prelink


### PR DESCRIPTION
The check 
`when: sysconfig_prelink_exists or etc_prelink_exists`
is always true, even file exists then not must be modified to 
 `when: sysconfig_prelink_exists.stat.exists or etc_prelink_exists.stat.exists`

Additionally, the file /etc/sysconfig/prelink is always created on my CentOS8.3 

I believe that prelink is not in game on latest RHEL.CentOS8 and then i changed the task to modify 
`/etc/sysconfig/prelink` 
file only if exists on the RedHat