### PR TITLE
The /tmp folder not  mounted on RHEL by tmp.mount

### DIFF
--- a/tasks/mount.yml
+++ b/tasks/mount.yml
@@ -74,4 +74,16 @@
     - mount
     - systemd
     - tmp
+
+- name: start tmp.mount
+  become: 'yes'
+  systemd:
+    name: tmp.mount
+    daemon_reload: 'yes'
+    state: started
+  when: ansible_os_family == "RedHat" and tmp_mount.stat.exists
+  tags:
+    - mount
+    - systemd
+    - tmp
 ...


### PR DESCRIPTION
To allow next hardening steps to be provided correctly the tmp folder have to be mounted by systemd on the RedHat system.

Otherwise role is aboered because dnf is not able to create tmp file for updates.