### PR TITLE
Fixed broken link for cryptographic policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ and packages to be removed (`packages_blocklist`).
 crypto_policy: FIPS
 ```
 
-Set [cryptographic policies](https://access.redhat.aom/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/using-the-system-wide-cryptographic-policies_security-hardening)
+Set [cryptographic policies](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/using-the-system-wide-cryptographic-policies_security-hardening)
 if `/etc/crypto-policies/config` exists.
 
 ### ./defaults/main/sshd.yml


### PR DESCRIPTION
Great repository @konstruktoid! I noticed a small typo in the link for *cryptographic policies* within the readme. It seems the correct link should be [this](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/using-the-system-wide-cryptographic-policies_security-hardening). This PR fixes it.