### PR TITLE
Missing compiler binary is not error for restrict access

### DIFF
--- a/tasks/compilers.yml
+++ b/tasks/compilers.yml
@@ -8,7 +8,8 @@
     state: file
     follow: 'yes'
     path: "{{ item }}"
-  ignore_errors: true
+  register: output
+  failed_when: "output.failed and output.state != 'absent'"
   with_items:
     - "{{ compilers }}"
   tags:


### PR DESCRIPTION
The compiler access change operation not failed, if the file not exists. But ansible reports the error here. Due this if failures are ignored, then info if compiler access rights change failed on existing file is supressed as not real error.

This commit implements that the operation do not report errors when file is missing, but reports error in all other cases.

Benefit is that role output doesn't contain red lines -> then no false positives that something is wrong