### PR TITLE
systemd tmp.mount  service fix

### DIFF
--- a/tasks/mount.yml
+++ b/tasks/mount.yml
@@ -71,7 +71,7 @@
     daemon_reload: 'yes'
     state: started
     enabled: 'yes'
-  when: ansible_os_family == "RedHat" and tmp_mount.stat.exists
+  when: tmp_mount.stat.exists
   tags:
     - mount
     - systemd

--- a/tasks/mount.yml
+++ b/tasks/mount.yml
@@ -32,11 +32,11 @@
     - mount
     - shm
 
-- name: create /tmp
+- name: create tmp.mount 
   become: 'yes'
   template:
     src: etc/systemd/tmp.mount.j2
-    dest: /lib/systemd/system/tmp.mount
+    dest: /etc/systemd/system/tmp.mount
     backup: 'yes'
     mode: 0644
     owner: root
@@ -47,7 +47,7 @@
 
 - name: stat tmp.mount
   stat:
-    path: /lib/systemd/system/tmp.mount
+    path: /etc/systemd/system/tmp.mount
   register: tmp_mount
   tags:
     - mount
@@ -64,23 +64,13 @@
     - systemd
     - tmp
 
-- name: enable tmp.mount
-  become: 'yes'
-  systemd:
-    name: tmp.mount
-    enabled: 'yes'
-  when: ansible_os_family == "RedHat" and tmp_mount.stat.exists
-  tags:
-    - mount
-    - systemd
-    - tmp
-
 - name: start tmp.mount
   become: 'yes'
   systemd:
     name: tmp.mount
     daemon_reload: 'yes'
     state: started
+    enabled: yes
   when: ansible_os_family == "RedHat" and tmp_mount.stat.exists
   tags:
     - mount

--- a/tasks/mount.yml
+++ b/tasks/mount.yml
@@ -32,7 +32,7 @@
     - mount
     - shm
 
-- name: create tmp.mount 
+- name: create tmp.mount
   become: 'yes'
   template:
     src: etc/systemd/tmp.mount.j2

--- a/tasks/mount.yml
+++ b/tasks/mount.yml
@@ -70,7 +70,7 @@
     name: tmp.mount
     daemon_reload: 'yes'
     state: started
-    enabled: yes
+    enabled: 'yes'
   when: ansible_os_family == "RedHat" and tmp_mount.stat.exists
   tags:
     - mount


### PR DESCRIPTION
I have discovered that /tmp is not mounted correctly after OS reboot. It is probbably caused by start statement withour explicit **enable: yes**.  When I have added this, the tmp.mount is invoked after reboot correctly.

The second fix is that all user modification to systemd service files have to be done at **/etc/systemd/system**, not in _/lib/sytemd/system_. The reason is that any systemd update can revert these changes back to default service file...

But I do not understand completely logic of the **mount.yml** tasks here. For example why the file is creatred always, and then enabled and started only on RedHat system. Especially because **any mount point for /tmp is removed from fstab** by fstab.yml without any conditions. Then sometimes /tmp can be not mounted  by tmpfs  and can be provided as classical folder under /root FS... 

Can you provide revision of the tmp.mount for non RedHat systems? Maybe it can be bug here, but not sure if I catch all logic behind this...

Please let me know. 