### PR TITLE
UEFI sytem boot fix

### DIFF
--- a/tasks/disablefs.yml
+++ b/tasks/disablefs.yml
@@ -13,4 +13,15 @@
     - "{{ fs_modules_blocklist }}"
   tags:
     - modprobe
+
+#When UEFI boot is used, VFAT can't be disabled!
+- name: delete block for VFAT if we are on UEFI system
+  become: 'yes'
+  lineinfile:
+    dest: /etc/modprobe.d/disablefs.conf
+    state: absent
+    regexp: "^install\\s*vfat"
+  when: booted_with_efi
+  tags:
+    - modprobe
 ...

--- a/tasks/pre.yml
+++ b/tasks/pre.yml
@@ -116,4 +116,10 @@
     - yum
     - packages
     - firewalld
+
+- name: EFI or UEFI booting check
+  set_fact:
+    booted_with_efi: "{{ ansible_mounts | selectattr('mount', 'equalto', '/boot/efi') | list | length > 0 }}"
+  tags:
+    - fact
 ...


### PR DESCRIPTION
My VM images are configured to use UEFI boot. Then VFAT module have to be enabled to keep them functional. This fix grant this without **fs_modules_blocklist** custom modification requirement