### PR TITLE
Use Ansible dnf instead of the shell command

### DIFF
--- a/tasks/packagemgmt.yml
+++ b/tasks/packagemgmt.yml
@@ -206,7 +206,7 @@
 - name: dnf upgrade
   become: 'yes'
   dnf:
-    name:  "*"      # noqa 403
+    name: "*" # noqa 403
     state: latest
     bugfix: 'yes'
     security: 'yes'

--- a/tasks/packagemgmt.yml
+++ b/tasks/packagemgmt.yml
@@ -205,9 +205,11 @@
 
 - name: dnf upgrade
   become: 'yes'
-  command: dnf --assumeyes upgrade-minimal
-  register: dnf_upgrade_response
-  changed_when: dnf_upgrade_response.stdout.find('Nothing to do.') == -1
+  dnf:
+    name:  "*"
+    state: latest
+    bugfix: 'yes'
+    security: 'yes'
   when: ansible_os_family == "RedHat" and system_upgrade|bool
   tags:
     - dnf

--- a/tasks/packagemgmt.yml
+++ b/tasks/packagemgmt.yml
@@ -206,7 +206,7 @@
 - name: dnf upgrade
   become: 'yes'
   dnf:
-    name:  "*"
+    name:  "*"      # noqa 403
     state: latest
     bugfix: 'yes'
     security: 'yes'


### PR DESCRIPTION
Ansible dnf module now support actions with same effect as 

- dnf upgrade-minimal

Then is recommended by ansible to use the module instead of the direct shell command (warning about that is generated)