### PR TITLE
Handle correctly SSH config sub-dirs

### DIFF
--- a/tasks/sshconfig.yml
+++ b/tasks/sshconfig.yml
@@ -1,4 +1,9 @@
 ---
+- name: check if sshd_config.d exits
+  stat:
+    path: /etc/ssh/sshd_config.d
+  register: sshd_config_d_exists
+
 - name: configure sshd
   become: 'yes'
   template:
@@ -33,8 +38,15 @@
     mode: 0600
     path: "{{ item.path }}"
   with_items: "{{ ssh_host_keys.files }}"
+  loop_control:
+    label: "{{ item.path }}"
   tags:
     - sshd
+
+- name: check if ssh_config.d exits
+  stat:
+    path: /etc/ssh/ssh_config.d
+  register: ssh_config_d_exists
 
 - name: configure ssh client
   become: 'yes'

--- a/templates/etc/ssh/ssh_config.j2
+++ b/templates/etc/ssh/ssh_config.j2
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
-{% if (ansible_distribution == "Ubuntu") and (ansible_distribution_major_version|int >= 20) %}
+{% if ssh_config_d_exists.stat.exists and ssh_config_d_exists.stat.isdir %}
 Include /etc/ssh/ssh_config.d/*.conf
 {% endif %}
 

--- a/templates/etc/ssh/sshd_config.j2
+++ b/templates/etc/ssh/sshd_config.j2
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
-{% if (ansible_distribution == "Ubuntu") and (ansible_distribution_major_version|int >= 20) %}
+{% if sshd_config_d_exists.stat.exists and sshd_config_d_exists.stat.isdir %}
 Include /etc/ssh/sshd_config.d/*.conf
 {% endif %}
 


### PR DESCRIPTION
The **ssh_config.d** and *sshd_config.d* directories inside the /etc/ssh are not limited only on the Ubuntu. 

Then I have modified the role to add Include directive distribution independent. Now it is generated to ssh(d) main config file based on it's real existence on the disk
