### PR TITLE
Generating auditd rules is now optional, handled by auditd_apply_audit_rules variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ See [TESTING.md](TESTING.md).
 ### ./defaults/main/auditd.yml
 
 ```yaml
+auditd_apply_audit_rules: 'yes'
 auditd_action_mail_acct: root
 auditd_admin_space_left_action: suspend
 auditd_disk_error_action: suspend
@@ -74,6 +75,11 @@ grub_audit_cmdline: audit=1
 ```
 
 Enable `auditd` at boot using Grub.
+
+`auditd_apply_audit_rules` When true, the role applies own auditd rules from the
+template file `hardening.rules.j2` To apply own rulesset (to be compliant with
+OSSEC scanner, for example) set here False and provide own ansible task to
+configure auditd.
 
 `auditd_action_mail_acct` should be a valid email address or alias.
 

--- a/defaults/main/auditd.yml
+++ b/defaults/main/auditd.yml
@@ -1,4 +1,5 @@
 ---
+auditd_apply_audit_rules: 'yes'
 auditd_action_mail_acct: root
 auditd_admin_space_left_action: suspend
 auditd_disk_error_action: suspend

--- a/tasks/auditd.yml
+++ b/tasks/auditd.yml
@@ -18,15 +18,7 @@
 
 - name: set RedHat audit grub cmdline
   become: 'yes'
-  lineinfile:
-    line: 'GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX {{ grub_audit_cmdline }} {{ grub_audit_backlog_cmdline }}"'
-    dest: /etc/default/grub
-    insertafter: '^GRUB_CMDLINE_LINUX="[a-z]+'
-    state: present
-    create: 'no'
-    mode: 0644
-    owner: root
-    group: root
+  shell: grubby --update-kernel=ALL --args=console="{{ grub_audit_cmdline }} {{ grub_audit_backlog_cmdline }}"
   notify:
     - update grub2
   when: ansible_os_family == "RedHat"
@@ -34,25 +26,6 @@
     - auditd
     - grub
 
-- name: check RedHat auditd ExecStartPost
-  environment:
-    PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-  command: grep -qo "^ExecStartPost=-/sbin/auditctl -R" /usr/lib/systemd/system/auditd.service
-  register: execstartpost_auditd_set
-  when: ansible_os_family == "RedHat"
-  changed_when: execstartpost_auditd_set.rc != 0
-  failed_when: execstartpost_auditd_set.rc > 1
-
-- name: set audit service execstartpost
-  become: 'yes'
-  lineinfile:
-    regexp: '#ExecStartPost=-/sbin/auditctl -R /etc/audit/audit.rules'
-    line: 'ExecStartPost=-/sbin/auditctl -R /etc/audit/audit.rules'
-    dest: /usr/lib/systemd/system/auditd.service
-    state: present
-  when: ansible_os_family == "RedHat" and execstartpost_auditd_set.rc != 0
-  tags:
-    - auditd
 
 - name: set audit action_mail_acct
   become: 'yes'
@@ -171,6 +144,7 @@
     mode: 0600
     owner: root
     group: root
+  when: auditd_apply_audit_rules|bool == true
   notify:
     - generate auditd
     - restart auditd

--- a/tasks/auditd.yml
+++ b/tasks/auditd.yml
@@ -18,7 +18,7 @@
 
 - name: set RedHat audit grub cmdline
   become: 'yes'
-  shell: grubby --update-kernel=ALL --args="{{ grub_audit_cmdline }} {{ grub_audit_backlog_cmdline }}"
+  command: grubby --update-kernel=ALL --args="{{ grub_audit_cmdline }} {{ grub_audit_backlog_cmdline }}"
   notify:
     - update grub2
   when: ansible_os_family == "RedHat"
@@ -144,7 +144,7 @@
     mode: 0600
     owner: root
     group: root
-  when: auditd_apply_audit_rules|bool == true
+  when: auditd_apply_audit_rules|bool
   notify:
     - generate auditd
     - restart auditd

--- a/tasks/auditd.yml
+++ b/tasks/auditd.yml
@@ -18,7 +18,7 @@
 
 - name: set RedHat audit grub cmdline
   become: 'yes'
-  shell: grubby --update-kernel=ALL --args=console="{{ grub_audit_cmdline }} {{ grub_audit_backlog_cmdline }}"
+  shell: grubby --update-kernel=ALL --args="{{ grub_audit_cmdline }} {{ grub_audit_backlog_cmdline }}"
   notify:
     - update grub2
   when: ansible_os_family == "RedHat"

--- a/tasks/post.yml
+++ b/tasks/post.yml
@@ -21,4 +21,6 @@
   changed_when: item.mode|int > 0400
   with_items:
     - "{{ grub_cfg.files | reject('search','/boot/efi/EFI/ubuntu/grub.cfg') | list }}"
+  loop_control:
+    label: "{{ item.path }}"
 ...

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -25,12 +25,14 @@
   tags:
     - users
 
-- name: user /home directory permissions
+- name: set user /home directories permission
   become: 'yes'
   file:
     mode: 0750
     path: "{{ item.path }}"
   with_items: "{{ home_directories.files }}"
+  loop_control:
+    label: "{{ item.path }}"
   tags:
     - users
 ...


### PR DESCRIPTION
As mentioned in issue #42 aplying auditd hardening rules is now driven by the `auditd_apply_audit_rules` variable. Documentation is changed as well.

During this modification, I have discovered that kernel parameters are modified by direct way, what can be problem if another task will try to add or remove any other kernel parameter - the $GRUB_CMDLINE_LINUX variable will not reflect new state, I think. I have modified this to RHEL/CentOS recommended way, use the **grubby** tool. It works smoothly and modify grubenv file by these parameters...

Next fixed issue is direct modification of the _/usr/lib/systemd/system/auditd.service_ file. The _"black magic"_ used here is no more necessary onto the CentOS/RHEL v 8 and v7. Here is enough to place rules to /etc/audit/rules.d directory. then auditd provide all other tasks itself. Verified by **auditctl -l** command -> rules are correctly applied.
 