### PR TITLE
Provide ability to exclude play groupings and individual plays

### DIFF
--- a/defaults/main/main_vars.yml
+++ b/defaults/main/main_vars.yml
@@ -1,0 +1,58 @@
+---
+# task-specific includes
+
+# sshconfig.yml
+arh_overwrite_ssh_config: true
+arh_overwrite_sshd_config: true
+arh_set_sshd_host_key_permissions: true
+
+# users.yml
+arh_modify_adduser_conf: true
+arh_overwrite_useradd: true
+
+
+# include top level vars in tasks/main.yml
+include_adduser: true
+include_aide: true
+include_apparmor: true
+include_apport: true
+include_auditd: true
+include_compilers: true
+include_cron: true
+include_ctrlaltdel: true
+include_disablefs: true
+include_disablemod: true
+include_disablenet: true
+include_extras: true
+include_firewall: true
+include_fstab: true
+include_hosts: true
+include_issue: true
+include_journalconf: true
+include_limits: true
+include_lockroot: true
+include_logindconf: true
+include_logindefs: true
+include_motdnews: true
+include_mount: true
+include_packagemgmt: true
+include_packages: true
+include_password: true
+include_path: true
+include_post: true
+include_postfix: true
+include_pre: true
+include_prelink: true
+include_resolvedconf: true
+include_rkhunter: true
+include_rootaccess: true
+include_sshconfig: true
+include_sudo: true
+include_suid: true
+include_sysctl: true
+include_systemdconf: true
+include_timesyncd: true
+include_umask: true
+include_users: true
+
+...

--- a/tasks/adduser.yml
+++ b/tasks/adduser.yml
@@ -1,5 +1,5 @@
 ---
-- name: adduser.conf
+- name: "overwrite adduser.conf"
   become: 'yes'
   template:
     src: etc/adduser.conf.j2
@@ -11,8 +11,9 @@
   tags:
     - adduser
     - users
+  when: arh_modify_adduser_conf is true
 
-- name: useradd
+- name: "overwrite useradd"
   become: 'yes'
   template:
     src: etc/default/useradd.j2
@@ -24,4 +25,5 @@
   tags:
     - useradd
     - users
+  when: arh_overwrite_useradd is true
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,136 +1,180 @@
 ---
 - name: configure local facts, install pexpect and epel-release
   include: pre.yml
+  when: no_include_pre is not defined
 
 - name: install and configure firewalls
   environment:
     PATH: /usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/bin
   include: firewall.yml
+  when: no_include_firewall is not defined
 
 - name: configure sysctl
   include: sysctl.yml
+  when: no_include_sysctl is not defined
 
 - name: disable kernel network modules
   include: disablenet.yml
+  when: no_include_disablenet is not defined
 
 - name: disable file system kernel modules
   include: disablefs.yml
+  when: no_include_disablefs is not defined
 
 - name: configure systemd system and users
   include: systemdconf.yml
+  when: no_include_systemdconf is not defined
 
 - name: configure systemd journald and logrotate
   include: journalconf.yml
+  when: no_include_journalconf is not defined
 
 - name: configure systemd timesyncd
   include: timesyncd.yml
+  when: no_include_timesyncd is not defined
 
 - name: clean fstab
   include: fstab.yml
+  when: no_include_fstab is not defined
 
 - name: configure shm and tmp mounts
   include: mount.yml
+  when: no_include_mount is not defined
 
 - name: disable prelink
   include: prelink.yml
+  when: no_include_prelink is not defined
 
 - name: configure package managers, update caches and install updates
   include: packagemgmt.yml
+  when: no_include_packagemgmt is not defined
 
 - name: configure hosts.allow and hosts.deny
   include: hosts.yml
+  when: no_include_hosts is not defined
 
 - name: configure login.defs
   include: logindefs.yml
+  when: no_include_logindefs is not defined
 
 - name: set limits
   include: limits.yml
+  when: no_include_limits is not defined
 
 - name: configure adduser and useradd
   include: adduser.yml
+  when: no_include_adduser is not defined
 
 - name: restrict root access
   include: rootaccess.yml
+  when: no_include_rootaccess is not defined
 
 - name: configure needrestart, install and remove various packages
   environment:
     PATH: /usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/bin
   include: packages.yml
+  when: no_include_packages is not defined
 
 - name: configure ssh server and client
   include: sshconfig.yml
+  when: no_include_sshconfig is not defined
 
 - name: configure pam
   include: password.yml
+  when: no_include_password is not defined
 
 - name: configure and clean at and cron
   include: cron.yml
+  when: no_include_cron is not defined
 
 - name: disable ctrl-alt-del.target
   include: ctrlaltdel.yml
+  when: no_include_ctrlaltdel is not defined
 
 - name: configure auditd
   include: auditd.yml
+  when: no_include_auditd is not defined
 
 - name: configure apparmor
   environment:
     PATH: /usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/bin
   include: apparmor.yml
+  when: no_include_apparmor is not defined
 
 - name: disable misc kernel modules
   include: disablemod.yml
+  when: no_include_disablemod is not defined
 
 #   https://bugs.launchpad.net/ubuntu/+source/aide/+bug/1903298
 - name: configure aide
   include: aide.yml
-  when: install_aide|bool and (not (ansible_distribution == "Ubuntu" and (ansible_lsb.codename == "groovy" or ansible_lsb.codename == "hirsute")))
+  when:
+    - install_aide|bool and (not (ansible_distribution == "Ubuntu" and (ansible_lsb.codename == "groovy" or ansible_lsb.codename == "hirsute")))
+    - no_include_aide is not defined
 
 - name: remove users
   include: users.yml
+  when: no_include_users is not defined
 
 - name: remove suid/sgid
   include: suid.yml
-  when: suid_sgid_permissions|bool
+  when:
+    - suid_sgid_permissions|bool
+    - no_include_suid is not defined
 
 - name: configure compiler permissions
   include: compilers.yml
+  when: no_include_compilers is not defined
 
 - name: set umask
   include: umask.yml
+  when: no_include_umask is not defined
 
 - name: configure paths
   include: path.yml
+  when: no_include_path is not defined
 
 - name: configure systemd logindconf
   include: logindconf.yml
+  when: no_include_logindconf is not defined
 
 - name: configure systemd resolvedconf
   include: resolvedconf.yml
+  when: no_include_resolvedconf is not defined
 
 - name: configure rkhunter
   include: rkhunter.yml
+  when: no_include_rkhunter is not defined
 
 - name: add issue message
   include: issue.yml
+  when: no_include_issue is not defined
 
 - name: disable apport
   include: apport.yml
+  when: no_include_apport is not defined
 
 - name: lock root account
   include: lockroot.yml
+  when: no_include_lockroot is not defined
 
 - name: configure postfix
   include: postfix.yml
+  when: no_include_postfix is not defined
 
 - name: configure motdnews
   include: motdnews.yml
+  when: no_include_motdnews is not defined
 
 - name: configure sudo
   include: sudo.yml
+  when: no_include_sudo is not defined
 
 - name: misc extra tasks
   include: extras.yml
+  when: no_include_extras is not defined
 
 - name: misc tasks after all handlers
   include: post.yml
+  when: no_include_post is not defined
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,180 +1,179 @@
 ---
 - name: configure local facts, install pexpect and epel-release
   include: pre.yml
-  when: no_include_pre is not defined
 
 - name: install and configure firewalls
   environment:
     PATH: /usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/bin
   include: firewall.yml
-  when: no_include_firewall is not defined
+  when: include_firewall is true
 
 - name: configure sysctl
   include: sysctl.yml
-  when: no_include_sysctl is not defined
+  when: include_sysctl is true
 
 - name: disable kernel network modules
   include: disablenet.yml
-  when: no_include_disablenet is not defined
+  when: include_disablenet is true
 
 - name: disable file system kernel modules
   include: disablefs.yml
-  when: no_include_disablefs is not defined
+  when: include_disablefs is true
 
 - name: configure systemd system and users
   include: systemdconf.yml
-  when: no_include_systemdconf is not defined
+  when: include_systemdconf is true
 
 - name: configure systemd journald and logrotate
   include: journalconf.yml
-  when: no_include_journalconf is not defined
+  when: include_journalconf is true
 
 - name: configure systemd timesyncd
   include: timesyncd.yml
-  when: no_include_timesyncd is not defined
+  when: include_timesyncd is true
 
 - name: clean fstab
   include: fstab.yml
-  when: no_include_fstab is not defined
+  when: include_fstab is true
 
 - name: configure shm and tmp mounts
   include: mount.yml
-  when: no_include_mount is not defined
+  when: include_mount is true
 
 - name: disable prelink
   include: prelink.yml
-  when: no_include_prelink is not defined
+  when: include_prelink is true
 
 - name: configure package managers, update caches and install updates
   include: packagemgmt.yml
-  when: no_include_packagemgmt is not defined
+  when: include_packagemgmt is true
 
 - name: configure hosts.allow and hosts.deny
   include: hosts.yml
-  when: no_include_hosts is not defined
+  when: include_hosts is true
 
 - name: configure login.defs
   include: logindefs.yml
-  when: no_include_logindefs is not defined
+  when: include_logindefs is true
 
 - name: set limits
   include: limits.yml
-  when: no_include_limits is not defined
+  when: include_limits is true
 
 - name: configure adduser and useradd
   include: adduser.yml
-  when: no_include_adduser is not defined
+  when: include_adduser is true
 
 - name: restrict root access
   include: rootaccess.yml
-  when: no_include_rootaccess is not defined
+  when: include_rootaccess is true
 
 - name: configure needrestart, install and remove various packages
   environment:
     PATH: /usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/bin
   include: packages.yml
-  when: no_include_packages is not defined
+  when: include_packages is true
 
 - name: configure ssh server and client
   include: sshconfig.yml
-  when: no_include_sshconfig is not defined
+  when: include_sshconfig is true
 
 - name: configure pam
   include: password.yml
-  when: no_include_password is not defined
+  when: include_password is true
 
 - name: configure and clean at and cron
   include: cron.yml
-  when: no_include_cron is not defined
+  when: include_cron is true
 
 - name: disable ctrl-alt-del.target
   include: ctrlaltdel.yml
-  when: no_include_ctrlaltdel is not defined
+  when: include_ctrlaltdel is true
 
 - name: configure auditd
   include: auditd.yml
-  when: no_include_auditd is not defined
+  when: include_auditd is true
 
 - name: configure apparmor
   environment:
     PATH: /usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/bin
   include: apparmor.yml
-  when: no_include_apparmor is not defined
+  when: include_apparmor is true
 
 - name: disable misc kernel modules
   include: disablemod.yml
-  when: no_include_disablemod is not defined
+  when: include_disablemod is true
 
 #   https://bugs.launchpad.net/ubuntu/+source/aide/+bug/1903298
 - name: configure aide
   include: aide.yml
   when:
     - install_aide|bool and (not (ansible_distribution == "Ubuntu" and (ansible_lsb.codename == "groovy" or ansible_lsb.codename == "hirsute")))
-    - no_include_aide is not defined
+    - include_aide is true
 
 - name: remove users
   include: users.yml
-  when: no_include_users is not defined
+  when: include_users is true
 
 - name: remove suid/sgid
   include: suid.yml
   when:
     - suid_sgid_permissions|bool
-    - no_include_suid is not defined
+    - include_suid is true
 
 - name: configure compiler permissions
   include: compilers.yml
-  when: no_include_compilers is not defined
+  when: include_compilers is true
 
 - name: set umask
   include: umask.yml
-  when: no_include_umask is not defined
+  when: include_umask is true
 
 - name: configure paths
   include: path.yml
-  when: no_include_path is not defined
+  when: include_path is true
 
 - name: configure systemd logindconf
   include: logindconf.yml
-  when: no_include_logindconf is not defined
+  when: include_logindconf is true
 
 - name: configure systemd resolvedconf
   include: resolvedconf.yml
-  when: no_include_resolvedconf is not defined
+  when: include_resolvedconf is true
 
 - name: configure rkhunter
   include: rkhunter.yml
-  when: no_include_rkhunter is not defined
+  when: include_rkhunter is true
 
 - name: add issue message
   include: issue.yml
-  when: no_include_issue is not defined
+  when: include_issue is true
 
 - name: disable apport
   include: apport.yml
-  when: no_include_apport is not defined
+  when: include_apport is true
 
 - name: lock root account
   include: lockroot.yml
-  when: no_include_lockroot is not defined
+  when: include_lockroot is true
 
 - name: configure postfix
   include: postfix.yml
-  when: no_include_postfix is not defined
+  when: include_postfix is true
 
 - name: configure motdnews
   include: motdnews.yml
-  when: no_include_motdnews is not defined
+  when: include_motdnews is true
 
 - name: configure sudo
   include: sudo.yml
-  when: no_include_sudo is not defined
+  when: include_sudo is true
 
 - name: misc extra tasks
   include: extras.yml
-  when: no_include_extras is not defined
+  when: include_extras is true
 
 - name: misc tasks after all handlers
   include: post.yml
-  when: no_include_post is not defined
+  when: include_post is true
 ...

--- a/tasks/sshconfig.yml
+++ b/tasks/sshconfig.yml
@@ -1,10 +1,13 @@
 ---
-- name: check if sshd_config.d exits
+- name: "check if sshd_config.d exits"
   stat:
     path: /etc/ssh/sshd_config.d
   register: sshd_config_d_exists
+  tags:
+    - sshd_config
+    - always
 
-- name: configure sshd
+- name: "overwrite sshd_config"
   become: 'yes'
   template:
     src: etc/ssh/sshd_config.j2
@@ -18,6 +21,7 @@
   tags:
     - sshd_config
     - sshd
+  when: arh_overwrite_sshd_config is true
 
 - name: sshd host keys
   become: 'yes'
@@ -29,8 +33,9 @@
   register: ssh_host_keys
   tags:
     - sshd
+    - always
 
-- name: sshd host key permissions
+- name: "set sshd host key permissions"
   become: 'yes'
   file:
     owner: root
@@ -42,13 +47,16 @@
     label: "{{ item.path }}"
   tags:
     - sshd
+  when: arh_set_sshd_host_key_permissions is true
 
-- name: check if ssh_config.d exits
+- name: "check if ssh_config.d exits"
   stat:
     path: /etc/ssh/ssh_config.d
   register: ssh_config_d_exists
+  tags:
+    - always
 
-- name: configure ssh client
+- name: "overwrite ssh_config"
   become: 'yes'
   template:
     src: etc/ssh/ssh_config.j2
@@ -60,4 +68,5 @@
   tags:
     - ssh_config
     - ssh
+  when: arh_overwrite_ssh_config is true
 ...


### PR DESCRIPTION
For your consideration:

A new file `defaults/main_vars.yml` defines variables to allow users to exclude groupings of plays for each included `.yml` in the ./tasks/ dir with the exception of the `pre.yml` include.

The `sshconfig.yml` and `users.yml` files in this PR have play-specific variables that will allow a user to conditionally exclude a specific play. The conditional variable is prefixed with `arh` and should follow the convention $PREFIX_$PLAY_NAME, substituting underscores in place of spaces and punctuation in the play's name. Play names that have been been refactored in this initial PR are now in quotes. 

Additionally, for absolute overkill, plays in these edited groupings that register info that may be used later have the `- always` tag included.  Those that have been updated now also have play names in quotes.

An example playbook might look like the following:

    ---
    - name: STIG baseline
      hosts: stig
      become: yes
      #TAGS_SKIP: ["packages"]
      roles:
        - ansible-role-hardening

      vars:
        include_sudo: false
        include_aide: false
        include_suid: false

        arh_set_sshd_host_key_permissions: true
        arh_overwrite_sshd_config: false
        arh_overwrite_ssh_config: false

These changes should not break existing implementations.
