### PR TITLE
remove net.ipv4.tcp_timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,7 +553,6 @@ sysctl_settings:
   net.ipv4.tcp_syn_retries: 5
   net.ipv4.tcp_synack_retries: 2
   net.ipv4.tcp_syncookies: 1
-  net.ipv4.tcp_timestamps: 0
   net.ipv6.conf.all.accept_ra: 0
   net.ipv6.conf.all.accept_redirects: 0
   net.ipv6.conf.all.accept_source_route: 0

--- a/defaults/main/sysctl.yml
+++ b/defaults/main/sysctl.yml
@@ -41,7 +41,6 @@ sysctl_settings:
   net.ipv4.tcp_syn_retries: 5
   net.ipv4.tcp_synack_retries: 2
   net.ipv4.tcp_syncookies: 1
-  net.ipv4.tcp_timestamps: 0
   net.ipv6.conf.all.accept_ra: 0
   net.ipv6.conf.all.accept_redirects: 0
   net.ipv6.conf.all.accept_source_route: 0

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -229,7 +229,6 @@
         - net.ipv4.tcp_syn_retries=5
         - net.ipv4.tcp_synack_retries=2
         - net.ipv4.tcp_syncookies=1
-        - net.ipv4.tcp_timestamps=0
         - net.ipv6.conf.all.accept_ra=0
         - net.ipv6.conf.all.accept_redirects=0
         - net.ipv6.conf.all.accept_source_route=0


### PR DESCRIPTION
Use the net.ipv4.tcp_timestamps defaults

Ref https://github.com/konstruktoid/hardening/issues/129

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>