### PR TITLE
Invisible character instead of space

### DIFF
--- a/tasks/disablemod.yml
+++ b/tasks/disablemod.yml
@@ -50,7 +50,7 @@
     state: present
     create: 'yes'
   with_items:
-    - "{{ modprobe_blacklist.stdout_lines | sort }}"
+    - "{{ modprobe_blacklist.stdout_lines | sort }}"
   when: block_blacklisted|bool
   tags:
     - modprobe


### PR DESCRIPTION
vscodium let me know:

```
The character U+00a0 is invisible.
```

Looks like that was in there. https://unicodeplus.com/U+00A0

Replaced by an actual space in there.