### PR TITLE
add disable_ipv6 variable

### DIFF
--- a/defaults/main/ipv6.yml
+++ b/defaults/main/ipv6.yml
@@ -1,0 +1,6 @@
+---
+disable_ipv6: false
+ipv6_sysctl_settings:
+  net.ipv6.conf.all.disable_ipv6: 1
+  net.ipv6.conf.default.disable_ipv6: 1
+...

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -15,6 +15,7 @@ provisioner:
   inventory:
     host_vars:
       arctic:
+        disable_ipv6: 'true'
         disable_wireless: 'true'
         sshd_admin_net: "0.0.0.0/0"
         sshd_allow_groups: "vagrant sudo"
@@ -33,6 +34,7 @@ provisioner:
         sshd_allow_groups: "vagrant sudo"
         suid_sgid_permissions: 'false'
       jammy:
+        disable_ipv6: 'true'
         block_blacklisted: 'true'
         disable_wireless: 'true'
         sshd_admin_net: "0.0.0.0/0"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -447,6 +447,35 @@
       changed_when: audit_grub_cfg.rc != 0
       when: ansible_os_family == "Debian"
 
+    - name: verify RedHat grub IPv6 settings
+      become: true
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep CMDLINE /etc/default/grub | grep "ipv6.disable=1"
+      register: audit_grubenv
+      failed_when: audit_grubenv.rc != 0
+      changed_when: audit_grubenv.rc != 0
+      when: ansible_os_family == "RedHat" and disable_ipv6
+
+    - name: verify Debian grub IPv6 settings
+      become: true
+      ansible.builtin.shell: grep "linux.*ipv6.disable=1" /boot/grub/grub.cfg
+      register: audit_grub_cfg
+      failed_when: audit_grub_cfg.rc != 0
+      changed_when: audit_grub_cfg.rc != 0
+      when: ansible_os_family == "Debian" and disable_ipv6
+
+    - name: verify IPv6 sysctl configuration
+      become: true
+      ansible.builtin.shell: grep -R "^{{ item }}$" /etc/sysctl.*
+      register: sysctl_config
+      failed_when: sysctl_config.rc != 0
+      changed_when: sysctl_config.rc != 0
+      with_items:
+        - net.ipv6.conf.all.disable_ipv6=1
+        - net.ipv6.conf.default.disable_ipv6=1
+      when: disable_ipv6
+
     - name: find grub config files
       become: true
       ansible.builtin.find:

--- a/tasks/ipv6.yml
+++ b/tasks/ipv6.yml
@@ -1,0 +1,44 @@
+---
+- name: set Debian ipv6.disable grub cmdline
+  become: true
+  ansible.builtin.lineinfile:
+    line: 'GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX ipv6.disable=1"'
+    dest: /etc/default/grub.d/99-hardening-ipv6.cfg
+    state: present
+    create: 'yes'
+    mode: 0755
+    owner: root
+    group: root
+  when: ansible_os_family == "Debian"
+  tags:
+    - ipv6
+    - grub
+    - CIS-UBUNTU2004-3.1.1
+
+- name: set RedHat ipv6.disable grub cmdline
+  become: true
+  ansible.builtin.command: 'grubby --update-kernel=ALL --args="ipv6.disable=1"'
+  register: grubby_update_kernel
+  when: ansible_os_family == "RedHat"
+  changed_when: grubby_update_kernel.rc != 0
+  failed_when: grubby_update_kernel.rc != 0
+  tags:
+    - ipv6
+    - grub
+
+- name: configure IPv6 sysctl settings
+  become: true
+  environment:
+    PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  ansible.posix.sysctl:
+    name: "{{ item.key }}"
+    value: "{{ item.value|int }}"
+    state: present
+    sysctl_set: 'yes'
+  with_dict: "{{ ipv6_sysctl_settings }}"
+  notify:
+    - restart sysctl
+  tags:
+    - ipv6
+    - sysctl
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,10 @@
 - name: disable file system kernel modules
   ansible.builtin.include_tasks: disablefs.yml
 
+- name: disable IPv6
+  ansible.builtin.include_tasks: ipv6.yml
+  when: disable_ipv6
+
 - name: configure systemd system and users
   ansible.builtin.include_tasks: systemdconf.yml
 


### PR DESCRIPTION
setting `disable_ipv6` to `true` will disable IPv6 functionality on the host

ref #118 

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>