### PR TITLE
Current code always deletes sftp Subystem directive

### DIFF
--- a/tasks/sshconfig.yml
+++ b/tasks/sshconfig.yml
@@ -149,11 +149,11 @@
     - UBTU-20-010037
 
 - name: See if an override sshd config file defines a Subsystem
-  shell: "grep -Iirn '^Subsystem.*' ."
+  ansible.builtin.shell: "grep -Iirn '^Subsystem.*' ."
   args:
     chdir: "/etc/ssh/sshd_config.d"
   register: grep_output
-  ignore_errors: true
+  failed_when: no
 
 - name: remove possible Subsystem duplicate when an override defines one
   become: true

--- a/tasks/sshconfig.yml
+++ b/tasks/sshconfig.yml
@@ -148,13 +148,24 @@
     - UBTU-20-010036
     - UBTU-20-010037
 
-- name: remove possible Subsystem duplicate
+- name: See if an override sshd config file defines a Subsystem
+  shell: "grep -Iirn '^Subsystem.*' ."
+  args:
+    chdir: "/etc/ssh/sshd_config.d"
+  register: grep_output
+  ignore_errors: true
+
+- name: remove possible Subsystem duplicate when an override defines one
   become: true
   ansible.builtin.lineinfile:
     path: /etc/ssh/sshd_config
     regexp: ^Subsystem.*
     state: absent
-  when: sshd_config_d.stat.exists and grep_include.rc == 0
+  when:
+    - sshd_config_d.stat.exists
+    - grep_include.rc == 0
+    - grep_output.stdout != ""
+    - grep_output.stdout_lines|length > 0
 
 - name: sshd host keys
   become: true


### PR DESCRIPTION
Ran into this. Suddenly couldn't sshfs directories anymore.

The current code checks for the existence of `/etc/ssh/sshd_config.d/` directory, but doesn't verify its contents.

If the `/etc/ssh/sshd_config.d/` directory exists, any `Subsystem` line will be removed from `/etc/ssh/sshd_config`. Even if there are no files under `/etc/ssh/sshd_config.d/` or the files don't contain a Subsystem directive.

This commit adds a check to see if `/etc/ssh/sshd_config.d/` contains a file with a `Subsystem` line in it.

And only removes the one in the default config file, it one was found in `/etc/ssh/sshd_config.d`