### PR TITLE
Add HostKeyAlgorithms configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ sshd_gssapi_authentication: 'no'
 sshd_hostbased_authentication: 'no'
 sshd_ignore_user_known_hosts: 'yes'
 sshd_kerberos_authentication: 'no'
+sshd_host_key_algorithms: ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com
 sshd_kex_algorithms: curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
 sshd_log_level: VERBOSE
 sshd_login_grace_time: 20

--- a/defaults/main/sshd.yml
+++ b/defaults/main/sshd.yml
@@ -3,7 +3,7 @@ sshd_accept_env: LANG LC_*
 sshd_admin_net:
   - 192.168.0.0/24
   - 192.168.1.0/24
-sshd_allow_agent_forwarding: 'no'
+sshd_allow_agent_forwarding: "no"
 sshd_allow_groups: sudo
 sshd_allow_tcp_forwarding: 'no'
 sshd_authentication_methods: any
@@ -17,6 +17,7 @@ sshd_gssapi_authentication: 'no'
 sshd_hostbased_authentication: 'no'
 sshd_ignore_user_known_hosts: 'yes'
 sshd_kerberos_authentication: 'no'
+sshd_host_key_algorithms: ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com
 sshd_kex_algorithms: curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
 sshd_log_level: VERBOSE
 sshd_login_grace_time: 20

--- a/defaults/main/sshd.yml
+++ b/defaults/main/sshd.yml
@@ -3,7 +3,7 @@ sshd_accept_env: LANG LC_*
 sshd_admin_net:
   - 192.168.0.0/24
   - 192.168.1.0/24
-sshd_allow_agent_forwarding: "no"
+sshd_allow_agent_forwarding: 'no'
 sshd_allow_groups: sudo
 sshd_allow_tcp_forwarding: 'no'
 sshd_authentication_methods: any

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -173,6 +173,7 @@
         - HostbasedAuthentication {{ sshd_hostbased_authentication }}
         - IgnoreUserKnownHosts {{ sshd_ignore_user_known_hosts }}
         - KerberosAuthentication {{ sshd_kerberos_authentication }}
+        - HostKeyAlgorithms {{ sshd_host_key_algorithms }}
         - KexAlgorithms {{ sshd_kex_algorithms }}
         - LogLevel {{ sshd_log_level }}
         - LoginGraceTime {{ sshd_login_grace_time|int }}
@@ -219,6 +220,7 @@
         - HostbasedAuthentication {{ sshd_hostbased_authentication }}
         - IgnoreUserKnownHosts {{ sshd_ignore_user_known_hosts }}
         - KerberosAuthentication {{ sshd_kerberos_authentication }}
+        - HostKeyAlgorithms {{ sshd_host_key_algorithms }}
         - KexAlgorithms {{ sshd_kex_algorithms }}
         - LogLevel {{ sshd_log_level }}
         - LoginGraceTime {{ sshd_login_grace_time|int }}

--- a/templates/etc/ssh/sshd_config.j2
+++ b/templates/etc/ssh/sshd_config.j2
@@ -14,6 +14,7 @@ GSSAPIAuthentication {{ sshd_gssapi_authentication }}
 HostbasedAuthentication {{ sshd_hostbased_authentication }}
 IgnoreUserKnownHosts {{ sshd_ignore_user_known_hosts }}
 KerberosAuthentication {{ sshd_kerberos_authentication }}
+HostKeyAlgorithms {{ sshd_host_key_algorithms }}
 KexAlgorithms {{ sshd_kex_algorithms }}
 LogLevel {{ sshd_log_level }}
 LoginGraceTime {{ sshd_login_grace_time|int }}


### PR DESCRIPTION
This PR brings the capabilities to configure `HostKeyAlgorithms`.

The default values are based on recommendations that [ssh-audit](https://github.com/jtesta/ssh-audit) gives.

Not much to say, I wait for your review and stay available :)

Thanks a lot for the role