### PR TITLE
Add conditional handling of ipv6 support on the OS.

### DIFF
--- a/defaults/main/ipv6.yml
+++ b/defaults/main/ipv6.yml
@@ -1,6 +1,6 @@
 ---
 disable_ipv6: false
-ipv6_sysctl_settings:
+ipv6_disable_sysctl_settings:
   net.ipv6.conf.all.disable_ipv6: 1
   net.ipv6.conf.default.disable_ipv6: 1
 ...

--- a/defaults/main/sysctl.yml
+++ b/defaults/main/sysctl.yml
@@ -1,22 +1,8 @@
 ---
 sysctl_dev_tty_ldisc_autoload: 0
 sysctl_net_ipv6_conf_accept_ra_rtr_pref: 0
-sysctl_settings:
-  fs.protected_fifos: 2
-  fs.protected_hardlinks: 1
-  fs.protected_symlinks: 1
-  fs.suid_dumpable: 0
-  kernel.core_uses_pid: 1
-  kernel.dmesg_restrict: 1
-  kernel.kptr_restrict: 2
-  kernel.panic: 60
-  kernel.panic_on_oops: 60
-  kernel.perf_event_paranoid: 3
-  kernel.randomize_va_space: 2
-  kernel.sysrq: 0
-  kernel.unprivileged_bpf_disabled: 1
-  kernel.yama.ptrace_scope: 2
-  net.core.bpf_jit_harden: 2
+
+ipv4_sysctl_settings:
   net.ipv4.conf.all.accept_redirects: 0
   net.ipv4.conf.all.accept_source_route: 0
   net.ipv4.conf.all.log_martians: 1
@@ -41,6 +27,8 @@ sysctl_settings:
   net.ipv4.tcp_syn_retries: 5
   net.ipv4.tcp_synack_retries: 2
   net.ipv4.tcp_syncookies: 1
+
+ipv6_sysctl_settings:
   net.ipv6.conf.all.accept_ra: 0
   net.ipv6.conf.all.accept_redirects: 0
   net.ipv6.conf.all.accept_source_route: 0
@@ -57,6 +45,23 @@ sysctl_settings:
   net.ipv6.conf.default.max_addresses: 1
   net.ipv6.conf.default.router_solicitations: 0
   net.ipv6.conf.default.use_tempaddr: 2
+
+regular_sysctl_settings:
+  fs.protected_fifos: 2
+  fs.protected_hardlinks: 1
+  fs.protected_symlinks: 1
+  fs.suid_dumpable: 0
+  kernel.core_uses_pid: 1
+  kernel.dmesg_restrict: 1
+  kernel.kptr_restrict: 2
+  kernel.panic: 60
+  kernel.panic_on_oops: 60
+  kernel.perf_event_paranoid: 3
+  kernel.randomize_va_space: 2
+  kernel.sysrq: 0
+  kernel.unprivileged_bpf_disabled: 1
+  kernel.yama.ptrace_scope: 2
+  net.core.bpf_jit_harden: 2
   net.netfilter.nf_conntrack_max: 2000000
   net.netfilter.nf_conntrack_tcp_loose: 0
 ...

--- a/defaults/main/sysctl.yml
+++ b/defaults/main/sysctl.yml
@@ -46,7 +46,7 @@ ipv6_sysctl_settings:
   net.ipv6.conf.default.router_solicitations: 0
   net.ipv6.conf.default.use_tempaddr: 2
 
-regular_sysctl_settings:
+generic_sysctl_settings:
   fs.protected_fifos: 2
   fs.protected_hardlinks: 1
   fs.protected_symlinks: 1

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -65,4 +65,15 @@
   ansible.builtin.setup: ~
   tags:
     - fact
+
+- name: Does local /proc have ipv6 settings?
+  become: true
+  ansible.builtin.stat:
+    path: /proc/sys/net/ipv6
+  register: stat_ipv6
+
+- name: Setting system has ipv6 or not.
+  ansible.builtin.set_fact:
+    system_has_ipv6: stat_ipv6.stat.exists
+
 ...

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -74,6 +74,6 @@
 
 - name: Setting system has ipv6 or not.
   ansible.builtin.set_fact:
-    system_has_ipv6: stat_ipv6.stat.exists
+    system_has_ipv6: "{{ stat_ipv6.stat.exists }}"
 
 ...

--- a/tasks/ipv6.yml
+++ b/tasks/ipv6.yml
@@ -35,7 +35,7 @@
     value: "{{ item.value|int }}"
     state: present
     sysctl_set: 'yes'
-  when: system_has_ipv6
+  when: system_has_ipv6 and disable_ipv6
   with_dict: "{{ ipv6_disable_sysctl_settings }}"
   notify:
     - restart sysctl

--- a/tasks/ipv6.yml
+++ b/tasks/ipv6.yml
@@ -26,6 +26,12 @@
     - ipv6
     - grub
 
+- name: Does local /proc have ipv6 settings?
+  become: true
+  ansible.builtin.stat:
+    path: /proc/sys/net/ipv6
+  register: has_ipv6
+
 - name: configure IPv6 sysctl settings
   become: true
   environment:
@@ -35,6 +41,7 @@
     value: "{{ item.value|int }}"
     state: present
     sysctl_set: 'yes'
+  when: has_ipv6.stat.exists
   with_dict: "{{ ipv6_sysctl_settings }}"
   notify:
     - restart sysctl

--- a/tasks/ipv6.yml
+++ b/tasks/ipv6.yml
@@ -36,7 +36,7 @@
     state: present
     sysctl_set: 'yes'
   when: system_has_ipv6
-  with_dict: "{{ ipv6_sysctl_settings }}"
+  with_dict: "{{ ipv6_disable_sysctl_settings }}"
   notify:
     - restart sysctl
   tags:

--- a/tasks/ipv6.yml
+++ b/tasks/ipv6.yml
@@ -26,12 +26,6 @@
     - ipv6
     - grub
 
-- name: Does local /proc have ipv6 settings?
-  become: true
-  ansible.builtin.stat:
-    path: /proc/sys/net/ipv6
-  register: has_ipv6
-
 - name: configure IPv6 sysctl settings
   become: true
   environment:
@@ -41,7 +35,7 @@
     value: "{{ item.value|int }}"
     state: present
     sysctl_set: 'yes'
-  when: has_ipv6.stat.exists
+  when: system_has_ipv6
   with_dict: "{{ ipv6_sysctl_settings }}"
   notify:
     - restart sysctl

--- a/tasks/sysctl.yml
+++ b/tasks/sysctl.yml
@@ -10,6 +10,12 @@
   tags:
     - sysctl
 
+- name: Does local /proc have ipv6 settings?
+  become: true
+  ansible.builtin.stat:
+    path: /proc/sys/net/ipv6
+  register: has_ipv6
+
 - name: set sysctl net.ipv6.conf.accept_ra_rtr_pref
   become: true
   ansible.posix.sysctl:
@@ -17,8 +23,19 @@
     value: "{{ sysctl_net_ipv6_conf_accept_ra_rtr_pref|int }}"
     state: present
     sysctl_set: 'yes'
+  when: has_ipv6.stat.exists
   tags:
     - sysctl
+
+- name: Sysctl rules if the system has ipv6
+  ansible.builtin.set_fact:
+    sysctl_settings: "{{ regular_sysctl_settings | combine(ipv4_sysctl_settings) | combine(ipv6_sysctl_settings) }}"
+  when: has_ipv6.stat.exists
+
+- name: Sysctl rules if the system does not have ipv6
+  ansible.builtin.set_fact:
+    sysctl_settings: "{{ regular_sysctl_settings | combine(ipv4_sysctl_settings) }}"
+  when: not has_ipv6.stat.exists
 
 - name: configure sysctl
   become: true

--- a/tasks/sysctl.yml
+++ b/tasks/sysctl.yml
@@ -10,12 +10,6 @@
   tags:
     - sysctl
 
-- name: Does local /proc have ipv6 settings?
-  become: true
-  ansible.builtin.stat:
-    path: /proc/sys/net/ipv6
-  register: has_ipv6
-
 - name: set sysctl net.ipv6.conf.accept_ra_rtr_pref
   become: true
   ansible.posix.sysctl:
@@ -23,19 +17,19 @@
     value: "{{ sysctl_net_ipv6_conf_accept_ra_rtr_pref|int }}"
     state: present
     sysctl_set: 'yes'
-  when: has_ipv6.stat.exists
+  when: system_has_ipv6
   tags:
     - sysctl
 
 - name: Sysctl rules if the system has ipv6
   ansible.builtin.set_fact:
-    sysctl_settings: "{{ regular_sysctl_settings | combine(ipv4_sysctl_settings) | combine(ipv6_sysctl_settings) }}"
-  when: has_ipv6.stat.exists
+    sysctl_settings: "{{ generic_sysctl_settings | combine(ipv4_sysctl_settings) | combine(ipv6_sysctl_settings) }}"
+  when: system_has_ipv6
 
 - name: Sysctl rules if the system does not have ipv6
   ansible.builtin.set_fact:
-    sysctl_settings: "{{ regular_sysctl_settings | combine(ipv4_sysctl_settings) }}"
-  when: not has_ipv6.stat.exists
+    sysctl_settings: "{{ generic_sysctl_settings | combine(ipv4_sysctl_settings) }}"
+  when: not system_has_ipv6
 
 - name: configure sysctl
   become: true


### PR DESCRIPTION
I ran into an issue where a Ubuntu 20.04 system did not have ipv6 support, or it was not enabled.

Either way: it wasn't showing up under /proc.

This leads to an issue where if you add these settings via sysctl, every time after that you use sysctl for something, or run an ansible playbook that does something with sysctl, you get an error.
Particularly, that the it `cannot stat` a location similar to `/proc/.../ipv6/...`

This PR adds conditional checking if the required directory exists and if it doesn't, omits setting ipv6 settings.

The approach is to put ipv4, ipv6 and other systctl setting in their own dict, and combining those based on ipv6 being available under `/proc` or not.