### PR TITLE
Add the possibility to keep /tmp mounted

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,14 @@ ufw_outgoing_traffic:
 
 Open `ufw` ports, allowing outgoing traffic.
 
+### ./defaults/main/fstab.yml
+
+```yaml
+fstab_remove_tmp: true
+```
+
+if `fstab_remove_tmp: true`, prevent `/tmp` from being mounted.
+
 ### ./defaults/main/ipv6.yml
 
 ```yaml

--- a/defaults/main/fstab.yml
+++ b/defaults/main/fstab.yml
@@ -1,0 +1,2 @@
+---
+fstab_remove_tmp: true

--- a/tasks/fstab.yml
+++ b/tasks/fstab.yml
@@ -4,6 +4,7 @@
   mount:
     path: /tmp
     state: absent
+  when: fstab_remove_tmp
   tags:
     - fstab
 


### PR DESCRIPTION
I've added the possibility to keep `/tmp` mounted on `fstab` as I believe this is a good practice to have `/tmp` mounted on a separated disk. This prevents `/tmp` to impact the system if this takes too much space.

I was looking for an article or something talking about it more officially but couldn't find it, unfortunately. There is this link https://superuser.com/questions/442383/why-should-i-make-a-separate-partition-for-tmp talking about it and that makes sense to me.

Was there any reason that I haven't thought about why you are removing it right now?