### PR TITLE
save sysctl settings to /usr/lib/sysctl.d/zz-hardening.conf

### DIFF
--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -42,6 +42,19 @@
         - sshd
         - sshd_config
 
+    - name: Stat IPv6 status
+      become: true
+      ansible.builtin.stat:
+        path: /proc/sys/net/ipv6
+      register: stat_ipv6
+
+    - name: Set IPv6 fact
+      ansible.builtin.set_fact:
+        system_has_ipv6: "{{ stat_ipv6.stat.exists }}"
+
+    - name: Update current facts
+      ansible.builtin.setup: ~
+
     - name: Verify auditd configuration
       become: true
       ansible.builtin.lineinfile:
@@ -320,70 +333,23 @@
         - MACs {{ sshd_macs }}
         - RekeyLimit {{ sshd_rekey_limit }}
 
-    - name: Verify sysctl configuration
+    - name: Merge sysctl settings
+      ansible.builtin.set_fact:
+        sysctl_settings: "{{ generic_sysctl_settings | combine(ipv4_sysctl_settings) }}"
+
+    - name: Verify sysctl runtime configuration
+      environment:
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       become: true
-      ansible.builtin.shell: grep -R "^{{ item }}$" /etc/sysctl.*
+      ansible.builtin.shell: |
+        set -o pipefail
+        sysctl -a | grep "^{{ item.key }}.*{{ item.value | int }}$"
+      args:
+        executable: /bin/bash
+      with_dict: "{{ sysctl_settings | dict2items | rejectattr('key', 'search', 'nf_conntrack') | items2dict }}"
       register: sysctl_config
       failed_when: sysctl_config.rc != 0
       changed_when: sysctl_config.rc != 0
-      with_items:
-        - fs.protected_fifos=2
-        - fs.protected_hardlinks=1
-        - fs.protected_symlinks=1
-        - fs.suid_dumpable=0
-        - kernel.core_uses_pid=1
-        - kernel.dmesg_restrict=1
-        - kernel.kptr_restrict=2
-        - kernel.panic=60
-        - kernel.panic_on_oops=60
-        - kernel.perf_event_paranoid=3
-        - kernel.randomize_va_space=2
-        - kernel.sysrq=0
-        - kernel.unprivileged_bpf_disabled=1
-        - kernel.yama.ptrace_scope=2
-        - net.core.bpf_jit_harden=2
-        - net.ipv4.conf.all.accept_redirects=0
-        - net.ipv4.conf.all.accept_source_route=0
-        - net.ipv4.conf.all.log_martians=1
-        - net.ipv4.conf.all.rp_filter=1
-        - net.ipv4.conf.all.secure_redirects=0
-        - net.ipv4.conf.all.send_redirects=0
-        - net.ipv4.conf.all.shared_media=0
-        - net.ipv4.conf.default.accept_redirects=0
-        - net.ipv4.conf.default.accept_source_route=0
-        - net.ipv4.conf.default.log_martians=1
-        - net.ipv4.conf.default.rp_filter=1
-        - net.ipv4.conf.default.secure_redirects=0
-        - net.ipv4.conf.default.send_redirects=0
-        - net.ipv4.conf.default.shared_media=0
-        - net.ipv4.icmp_echo_ignore_broadcasts=1
-        - net.ipv4.icmp_ignore_bogus_error_responses=1
-        - net.ipv4.ip_forward=0
-        - net.ipv4.tcp_challenge_ack_limit=2147483647
-        - net.ipv4.tcp_invalid_ratelimit=500
-        - net.ipv4.tcp_max_syn_backlog=20480
-        - net.ipv4.tcp_rfc1337=1
-        - net.ipv4.tcp_syn_retries=5
-        - net.ipv4.tcp_synack_retries=2
-        - net.ipv4.tcp_syncookies=1
-        - net.ipv6.conf.all.accept_ra=0
-        - net.ipv6.conf.all.accept_redirects=0
-        - net.ipv6.conf.all.accept_source_route=0
-        - net.ipv6.conf.all.forwarding=0
-        - net.ipv6.conf.all.use_tempaddr=2
-        - net.ipv6.conf.default.accept_ra=0
-        - net.ipv6.conf.default.accept_ra_defrtr=0
-        - net.ipv6.conf.default.accept_ra_pinfo=0
-        - net.ipv6.conf.default.accept_ra_rtr_pref=0
-        - net.ipv6.conf.default.accept_redirects=0
-        - net.ipv6.conf.default.accept_source_route=0
-        - net.ipv6.conf.default.autoconf=0
-        - net.ipv6.conf.default.dad_transmits=0
-        - net.ipv6.conf.default.max_addresses=1
-        - net.ipv6.conf.default.router_solicitations=0
-        - net.ipv6.conf.default.use_tempaddr=2
-        - net.netfilter.nf_conntrack_max=2000000
-        - net.netfilter.nf_conntrack_tcp_loose=0
 
     - name: Stat crypto-policies config
       become: true

--- a/tasks/sysctl.yml
+++ b/tasks/sysctl.yml
@@ -46,6 +46,7 @@
     value: "{{ item.value | int }}"
     state: present
     sysctl_set: true
+    sysctl_file: /usr/lib/sysctl.d/zz-hardening.conf
   with_dict: "{{ sysctl_settings }}"
   notify:
     - Restart sysctl


### PR DESCRIPTION
This PR:
- ensures we verify runtime sysctl settings, and not just config file values
- saves the sysctl settings to /usr/lib/sysctl.d/zz-hardening.conf so it won't be overwritten by default, see https://www.man7.org/linux/man-pages/man5/sysctl.d.5.html
- closes https://github.com/konstruktoid/ansible-role-hardening/issues/192