### PR TITLE
Use /usr/bin/aide --check instead of wrapper

### DIFF
--- a/templates/lib/systemd/system/aidecheck.service.j2
+++ b/templates/lib/systemd/system/aidecheck.service.j2
@@ -4,7 +4,7 @@ Description=Aide Check
 [Service]
 Type=simple
 {% if ansible_os_family == 'Debian' %}
-ExecStart=/usr/bin/aide.wrapper --check
+ExecStart=/usr/bin/aide --check --config /etc/aide/aide.conf
 {% else %}
 ExecStart=/usr/sbin/aide --check
 {% endif %}


### PR DESCRIPTION
Use /usr/bin/aide --check --config /etc/aide/aide.conf since aide.wrapper has been removed in jammy

ref https://github.com/konstruktoid/hardening/issues/196

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>