### PR TITLE
Add support for @AlmaLinux 9

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,7 @@ galaxy_info:
     - name: EL
       versions:
         - "8"
+        - "9"
     - name: Ubuntu
       versions:
         - focal

--- a/molecule/almalinux/molecule.yml
+++ b/molecule/almalinux/molecule.yml
@@ -17,21 +17,23 @@ provisioner:
   log: true
   inventory:
     host_vars:
-      arctic:
+      stone:
         sshd_admin_net: "0.0.0.0/0"
         sshd_allow_groups: "vagrant sudo"
-      emerald:
+        suid_sgid_permissions: false
+      lime:
         sshd_admin_net: "0.0.0.0/0"
         sshd_allow_groups: "vagrant sudo"
+        suid_sgid_permissions: false
 platforms:
-  - name: arctic
+  - name: stone
     box: "almalinux/8"
     config_options:
       vm.boot_timeout: 600
     instance_raw_config_args:
       - 'vbguest.auto_update = false'
     memory: 1024
-  - name: emerald
+  - name: lime
     box: "almalinux/9"
     config_options:
       vm.boot_timeout: 600

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,9 +14,15 @@ provisioner:
   log: true
   inventory:
     host_vars:
-      arctic:
+      stone:
         disable_ipv6: true
         disable_wireless: true
+        install_aide: false
+        sshd_admin_net: "0.0.0.0/0"
+        sshd_allow_groups: "vagrant sudo"
+        suid_sgid_permissions: false
+      lime:
+        disable_ipv6: true
         sshd_admin_net: "0.0.0.0/0"
         sshd_allow_groups: "vagrant sudo"
       bullseye:
@@ -41,8 +47,15 @@ provisioner:
         sshd_allow_groups: "vagrant sudo"
         suid_sgid_permissions: false
 platforms:
-  - name: arctic
+  - name: stone
     box: "almalinux/8"
+    config_options:
+      vm.boot_timeout: 600
+    instance_raw_config_args:
+      - 'vbguest.auto_update = false'
+    memory: 1024
+  - name: lime
+    box: "almalinux/9"
     config_options:
       vm.boot_timeout: 600
     instance_raw_config_args:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -131,9 +131,10 @@
         path: '/etc/ssh/ssh_config'
       register: ssh_config_file
 
-    - name: Stat /etc/ssh/sshd_config.d/hardening.conf
+    - name: Stat /etc/ssh/sshd_config.d/01-hardening.conf
+      become: true
       ansible.builtin.stat:
-        path: '/etc/ssh/sshd_config.d/hardening.conf'
+        path: '/etc/ssh/sshd_config.d/01-hardening.conf'
       register: sshd_config_directory
 
     - name: Assert /etc/ssh/ssh_config permissions
@@ -150,7 +151,7 @@
         success_msg: "{{ sshd_config_file.stat.path }} has correct permissions: {{ sshd_config_file.stat.mode }}"
         fail_msg: "{{ sshd_config_file.stat.path }} permissions are incorrect: {{ sshd_config_file.stat.mode }}"
 
-    - name: Assert /etc/ssh/sshd_config.d/hardening.conf permissions
+    - name: Assert /etc/ssh/sshd_config.d/01-hardening.conf permissions
       ansible.builtin.assert:
         that:
           - sshd_config_directory.stat.mode == "0600"
@@ -171,7 +172,7 @@
     - name: Verify sshd_config.d PermitRootLogin configuration
       become: true
       ansible.builtin.lineinfile:
-        dest: /etc/ssh/sshd_config.d/hardening.conf
+        dest: /etc/ssh/sshd_config.d/01-hardening.conf
         line: "PermitRootLogin yes"
         state: absent
       check_mode: true
@@ -229,7 +230,7 @@
     - name: Verify sshd_config.d configuration
       become: true
       ansible.builtin.lineinfile:
-        dest: /etc/ssh/sshd_config.d/hardening.conf
+        dest: /etc/ssh/sshd_config.d/01-hardening.conf
         line: "{{ item }}"
         state: present
       check_mode: true
@@ -277,7 +278,7 @@
     - name: Verify sshd RequiredRSASize
       become: true
       ansible.builtin.lineinfile:
-        dest: /etc/ssh/sshd_config.d/hardening.conf
+        dest: /etc/ssh/sshd_config.d/01-hardening.conf
         line: "RequiredRSASize {{ sshd_required_rsa_size }}"
         state: present
       check_mode: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -444,7 +444,7 @@
       become: true
       ansible.builtin.shell: |
         set -o pipefail
-        grep CMDLINE /etc/default/grub | grep "{{ grub_audit_backlog_cmdline }}" | grep "{{ grub_audit_cmdline }}"
+        grubby --info="/boot/vmlinuz-$(uname -r)" | grep "^args.*{{ grub_audit_cmdline }} {{ grub_audit_backlog_cmdline }}"
       register: audit_grubenv
       failed_when: audit_grubenv.rc != 0
       changed_when: audit_grubenv.rc != 0
@@ -463,7 +463,7 @@
       ansible.builtin.shell:
         cmd: |
           set -o pipefail
-          grep CMDLINE /etc/default/grub | grep "ipv6.disable=1"
+          grubby --info="/boot/vmlinuz-$(uname -r)" | grep "ipv6.disable=1"
       register: audit_grubenv
       failed_when: audit_grubenv.rc != 0
       changed_when: audit_grubenv.rc != 0

--- a/tasks/packagemgmt.yml
+++ b/tasks/packagemgmt.yml
@@ -205,6 +205,7 @@
   ansible.builtin.stat:
     path: "{{ item }}"
   with_items:
+    - /etc/yum.repos.d/almalinux-crb.repo
     - /etc/yum.repos.d/almalinux-powertools.repo
     - /etc/yum.repos.d/CentOS-Linux-PowerTools.repo
     - /etc/yum.repos.d/CentOS-PowerTools.repo

--- a/tasks/post.yml
+++ b/tasks/post.yml
@@ -19,7 +19,7 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      grep "CMDLINE_LINUX=.*{{ grub_audit_cmdline }} {{ grub_audit_backlog_cmdline }}" /etc/default/grub
+      grubby --info="/boot/vmlinuz-$(uname -r)" | grep "^args.*{{ grub_audit_cmdline }} {{ grub_audit_backlog_cmdline }}"
   changed_when: false
   failed_when: false
   args:

--- a/tasks/sshconfig.yml
+++ b/tasks/sshconfig.yml
@@ -126,7 +126,7 @@
   become: true
   ansible.builtin.template:
     src: etc/ssh/sshd_config.j2
-    dest: /etc/ssh/sshd_config.d/hardening.conf
+    dest: /etc/ssh/sshd_config.d/01-hardening.conf
     backup: true
     mode: 0600
     owner: root


### PR DESCRIPTION
This PR updates the `sshd` configuration to fit AlmaLinux 9 and also makes use of `grubby` to set and verify `grub` options.