### PR TITLE
Added extra clarification on blacklist/block functionality of modprobe and what the code in this project does.

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,14 @@ of `blacklisted` kernel modules. The reasoning behind this is that a blacklisted
 module can still be loaded manually with `modprobe module_name`. Using
 `install module_name /bin/true` prevents this.
 
+**Please note:** This will affect modules that the OS itself has blacklisted as
+part of its default setup, or that were added manually at some point, by anyone
+with access to your system. Please verify the affected modules before turning
+this on, under `/etc/modprobe.d/`.
+
+This code project does not blacklist any modules, it only blocks/disables, as
+described in the first paragraph of this section.
+
 Note that disabling the `usb-storage` module will disable any usage of USB
 storage devices, if such devices are needed [USBGuard](https://github.com/USBGuard/usbguard),
 or a similar tool, should be configured accordingly.


### PR DESCRIPTION
I was recently going over the code and was confused for a good half hour on what the blocking of blacklisted module exactly does.

As this project only adds `install ... /bin/true` statements. It does not do any blacklists, but I kept seeing the term coming up, so I was looking for where and if the code did that.

Hope what I wrote might save future readers some trouble.