### PR TITLE
Added an rc.local file, to re-read the sysctl settings right after all normal services have been started, after boot.

### DIFF
--- a/tasks/ipv6.yml
+++ b/tasks/ipv6.yml
@@ -41,3 +41,14 @@
     - Restart sysctl
   tags:
     - ipv6
+
+- name: Confire rc.local
+  become: true
+  ansible.builtin.template:
+    src: etc/rc.local.j2
+    dest: /etc/rc.local
+    backup: true
+    mode: "0755"
+    owner: root
+    group: root
+  when: system_has_ipv6 and disable_ipv6

--- a/templates/etc/rc.local.j2
+++ b/templates/etc/rc.local.j2
@@ -1,0 +1,8 @@
+#!/bin/bash
+# /etc/rc.local
+
+/etc/sysctl.d
+{{ '/usr/lib/sysctl.d' if usr_lib_sysctl_d.stat.exists else "" }}
+/etc/init.d/procps restart
+
+exit 0


### PR DESCRIPTION
I was testing disabling ipv6 with a new set of Ubuntu 20 vms, and I noticed on reboot, the interfaces still had IPV6 addresses.

Checking sysctl, they had the settings I expected:

```
  net.ipv6.conf.all.disable_ipv6: 1
  net.ipv6.conf.default.disable_ipv6: 1
  net.ipv6.conf.lo.disable_ipv6: 1
```

Same with the grub configuration.

But, after every reboot, still had ipv6 addresses.

Googling around, I found that adding a file at `/etc/rc.local` could help.

I found this here: https://itsfoss.com/disable-ipv6-ubuntu-linux/

And some explanation here: https://unix.stackexchange.com/questions/49626/purpose-and-typical-usage-of-etc-rc-local

> The script /etc/rc.local is for use by the system administrator. It is traditionally executed after all the normal system services are started, at the end of the process of switching to a multiuser runlevel

Adding this file does consistently result in the interfaces not having an ipv6 address after reboot.


That being said, I find this quite strange. As the explanation says, you should almost never need `/etc/rc.local`. And it calling `/etc/init.d/procps restart` also seems antiquated, although I would have no way to know, it just feels that way.


I offer this PR as my solution, but it would be nice to see if the problem could be confirmed.

Like I said: all sysctl settings after reboot were as expected... but upon checking the interfaces, they had IPV6 addresses.