### PR TITLE
Improvements restrict compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ packages_redhat:
   - needrestart
   - postfix
   - psacct
+  - python3-dnf-plugin-post-transaction-actions
   - rkhunter
   - rsyslog
   - rsyslog-gnutls

--- a/defaults/main/packages.yml
+++ b/defaults/main/packages.yml
@@ -59,6 +59,7 @@ packages_redhat:
   - needrestart
   - postfix
   - psacct
+  - python3-dnf-plugin-post-transaction-actions
   - rkhunter
   - rsyslog
   - rsyslog-gnutls

--- a/tasks/compilers.yml
+++ b/tasks/compilers.yml
@@ -25,6 +25,7 @@
     - compilers
 
 - name: Ensure restrict compilers access via dpkg-statoverride
+  become: true
   ansible.builtin.command: dpkg-statoverride --update --force-all --add root root 0750 "{{ item.path }}"
   register: dpkg_statoverride
   changed_when: dpkg_statoverride.rc != 0

--- a/tasks/compilers.yml
+++ b/tasks/compilers.yml
@@ -11,7 +11,7 @@
   tags:
     - compilers
 
-- name: Restrict compiler access
+- name: Restrict compilers access
   become: true
   ansible.builtin.file:
     path: "{{ item.path }}"
@@ -20,7 +20,22 @@
     mode: "0750"
     state: file
     follow: true
-  with_items:
-    - "{{ compiler.files }}"
+  loop: "{{ compiler.files }}"
+  tags:
+    - compilers
+
+- name: Ensure restrict compilers access via dpkg-statoverride
+  ansible.builtin.command: dpkg-statoverride --update --force-all --add root root 0750 "{{ item.path }}"
+  register: dpkg_statoverride
+  changed_when: dpkg_statoverride.rc != 0
+  loop: "{{ compiler.files }}"
+  when: ansible_os_family == 'Debian'
+  tags:
+    - compilers
+
+- name: Ensure restrict compilers access via DNF post-transaction-actions Plugin
+  ansible.builtin.include_tasks: compilers_dnf_post_transaction_actions_plugin.yml
+  loop: "{{ compiler.files | map(attribute='path') | unique }}"
+  when: ansible_os_family == 'RedHat'
   tags:
     - compilers

--- a/tasks/compilers_dnf_post_transaction_actions_plugin.yml
+++ b/tasks/compilers_dnf_post_transaction_actions_plugin.yml
@@ -19,6 +19,6 @@
         create: true
         owner: root
         group: root
-        mode: 0644
+        mode: "0644"
         state: present
       when: compiler_package is defined and compiler_package.rc == 0

--- a/tasks/compilers_dnf_post_transaction_actions_plugin.yml
+++ b/tasks/compilers_dnf_post_transaction_actions_plugin.yml
@@ -1,0 +1,24 @@
+---
+- name: Ensure restrict compilers access via DNF post-transaction-actions Plugin
+  tags:
+    - compilers
+  block:
+    - name: Get package name rpm of binary file {{ item }}
+      become: true
+      ansible.builtin.command: rpm --query --queryformat='%{NAME}' --file {{ item }}  # noqa command-instead-of-module
+      register: compiler_package
+      changed_when: compiler_package.rc != 0
+      check_mode: false
+
+    - name: Ensure restrict compilers access via DNF post-transaction-actions Plugin for {{ item }}
+      become: true
+      ansible.builtin.lineinfile:
+        dest: /etc/dnf/plugins/post-transaction-actions.d/compilers.action
+        regexp: '{{ compiler_package.stdout }}:in:chown root:root "{{ item }}" && chmod 0750 "{{ item }}"'
+        line: '{{ compiler_package.stdout }}:in:chown root:root "{{ item }}" && chmod 0750 "{{ item }}"'
+        create: true
+        owner: root
+        group: root
+        mode: 0644
+        state: present
+      when: compiler_package is defined and compiler_package.rc == 0


### PR DESCRIPTION
Use `dpkg-statoverride` and `DNF post-transaction-actions Plugin` to ensure restrictive permissions on binaries during package installation and upgrades.

More details:
- https://man7.org/linux/man-pages/man1/dpkg-statoverride.1.html
- https://dnf-plugins-core.readthedocs.io/en/latest/post-transaction-actions.html