### PR TITLE
Updated SSHD configuration for allowed ciphers, keys, kex, mac, etc...

### DIFF
--- a/defaults/main/sshd.yml
+++ b/defaults/main/sshd.yml
@@ -21,7 +21,10 @@ sshd_challenge_response_authentication: "no"
 sshd_ciphers: >-
   chacha20-poly1305@openssh.com,
   aes256-gcm@openssh.com,
-  aes256-ctr
+  aes128-gcm@openssh.com,
+  aes256-ctr,
+  aes192-ctr,
+  aes128-ctr
 sshd_client_alive_count_max: 1
 sshd_client_alive_interval: 200
 sshd_compression: "no"
@@ -31,7 +34,8 @@ sshd_host_key_algorithms: >-
   ssh-ed25519-cert-v01@openssh.com,
   ssh-rsa-cert-v01@openssh.com,
   ssh-ed25519,
-  ssh-rsa,
+  rsa-sha2-256,
+  rsa-sha2-512,
   ecdsa-sha2-nistp521-cert-v01@openssh.com,
   ecdsa-sha2-nistp384-cert-v01@openssh.com,
   ecdsa-sha2-nistp256-cert-v01@openssh.com,
@@ -43,17 +47,16 @@ sshd_ignore_user_known_hosts: "yes"
 sshd_kerberos_authentication: "no"
 sshd_kex_algorithms: >-
   curve25519-sha256@libssh.org,
-  ecdh-sha2-nistp521,
-  ecdh-sha2-nistp384,
-  ecdh-sha2-nistp256,
-  diffie-hellman-group-exchange-sha256
+  curve25519-sha256,
+  diffie-hellman-group-exchange-sha256,
+  diffie-hellman-group16-sha512,
+  diffie-hellman-group18-sha512
 sshd_login_grace_time: 20
 sshd_log_level: VERBOSE
 sshd_macs: >-
   hmac-sha2-512-etm@openssh.com,
   hmac-sha2-256-etm@openssh.com,
-  hmac-sha2-512,
-  hmac-sha2-256
+  umac-128-etm@openssh.com
 sshd_max_auth_tries: 3
 sshd_max_sessions: 3
 sshd_max_startups: 10:30:60


### PR DESCRIPTION
Based on suggestions found here: 

https://blog.stribik.technology/2015/01/04/secure-secure-shell.html

And here: https://github.com/jtesta/ssh-audit

Which itself also gets info from here: https://www.ssh-audit.com/hardening_guides.html


That being said, I'm no expert and am just following advice given that seems to be trusted.