### PR TITLE
Allow non-integer sysctl values

### DIFF
--- a/tasks/sysctl.yml
+++ b/tasks/sysctl.yml
@@ -45,7 +45,7 @@
     PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
   ansible.posix.sysctl:
     name: "{{ item.key }}"
-    value: "{{ item.value | int }}"
+    value: "{{ item.value }}"
     state: present
     sysctl_set: true
     sysctl_file: "{{ sysctl_conf_dir }}/zz-hardening.conf"


### PR DESCRIPTION
Sysctl can have non-integer values, like:
  - net.ipv4.ip_local_port_range: 2000 65535
  - net.ipv4.tcp_rmem: 4096 87380 16777216
  - net.ipv4.tcp_wmem: 4096 87380 16777216
  - net.ipv4.udp_mem: 3145728 4194304 16777216