### PR TITLE
Sysctl error encountered, deploying to host with ipv6 disabled.

### DIFF
--- a/tasks/sysctl.yml
+++ b/tasks/sysctl.yml
@@ -7,6 +7,7 @@
     state: present
     sysctl_set: true
     sysctl_file: "{{ sysctl_conf_dir }}/zz-hardening.conf"
+    ignoreerrors: true
   when: ansible_kernel is version("5", ">=")
   tags:
     - sysctl
@@ -19,6 +20,7 @@
     state: present
     sysctl_set: true
     sysctl_file: "{{ sysctl_conf_dir }}/zz-hardening.conf"
+    ignoreerrors: true
   when: system_has_ipv6
   tags:
     - ipv6
@@ -49,6 +51,7 @@
     state: present
     sysctl_set: true
     sysctl_file: "{{ sysctl_conf_dir }}/zz-hardening.conf"
+    ignoreerrors: true
   with_dict: "{{ sysctl_settings }}"
   notify:
     - Restart sysctl


### PR DESCRIPTION
In case ipv6 has been disabled via grub, sysctl settings cannot be found and trying to run sysctl in this playbook throws an error, stopping the play.

This happens deploying the sysctl playbook against a host that previously had the ipv6 settings added to the zz-hardening.conf file.

These changes fix that, as per the documentation: https://docs.ansible.com/ansible/latest/collections/ansible/posix/sysctl_module.html