### PR TITLE
Put apt hardening options in variable

### DIFF
--- a/defaults/main/packagemgmt.yml
+++ b/defaults/main/packagemgmt.yml
@@ -1,3 +1,4 @@
+---
 apt_hardening_options:
   - Acquire::AllowDowngradeToInsecureRepositories "false";
   - Acquire::AllowInsecureRepositories "false";

--- a/defaults/main/packagemgmt.yml
+++ b/defaults/main/packagemgmt.yml
@@ -1,0 +1,12 @@
+apt_hardening_options:
+  - Acquire::AllowDowngradeToInsecureRepositories "false";
+  - Acquire::AllowInsecureRepositories "false";
+  - Acquire::http::AllowRedirect "false";
+  - APT::Get::AllowUnauthenticated "false";
+  - APT::Get::AutomaticRemove "true";
+  - APT::Install-Recommends "false";
+  - APT::Install-Suggests "false";
+  - APT::Periodic::AutocleanInterval "7";
+  - APT::Sandbox::Seccomp "1";
+  - Unattended-Upgrade::Remove-Unused-Dependencies "true";
+  - Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";

--- a/tasks/packagemgmt.yml
+++ b/tasks/packagemgmt.yml
@@ -7,18 +7,7 @@
     state: present
     create: true
     line: "{{ item }}"
-  loop:
-    - Acquire::AllowDowngradeToInsecureRepositories "false";
-    - Acquire::AllowInsecureRepositories "false";
-    - Acquire::http::AllowRedirect "false";
-    - APT::Get::AllowUnauthenticated "false";
-    - APT::Get::AutomaticRemove "true";
-    - APT::Install-Recommends "false";
-    - APT::Install-Suggests "false";
-    - APT::Periodic::AutocleanInterval "7";
-    - APT::Sandbox::Seccomp "1";
-    - Unattended-Upgrade::Remove-Unused-Dependencies "true";
-    - Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
+  loop: "{{ apt_hardening_options }}"
   when:
     - ansible_os_family == "Debian"
   tags:


### PR DESCRIPTION
While using this role on a plain install of Ubuntu 22.04 I was not able to upgrade packages. This was because redirects were happening with the official repos.

This PR puts the apt hardening options in a variable, making it easier to customize without messing with the role itself.

Defaults still kept as is.