### PR TITLE
Redhat block named after Debian, fixed.

### DIFF
--- a/tasks/pre.yml
+++ b/tasks/pre.yml
@@ -28,7 +28,7 @@
         - packages
         - python
 
-- name: Debian family pre tasks
+- name: RedHat family pre tasks
   become: true
   when:
     - ansible_os_family == "RedHat"


### PR DESCRIPTION
Just happened to notice. A typo.