### PR TITLE
set sysctl conf dir as default variable

### DIFF
--- a/defaults/main/sysctl.yml
+++ b/defaults/main/sysctl.yml
@@ -1,5 +1,6 @@
 ---
 manage_sysctl: true
+sysctl_conf_dir: "{{ '/usr/lib/sysctl.d' if usr_lib_sysctl_d_dir else '/etc/sysctl.d' }}"
 
 sysctl_dev_tty_ldisc_autoload: 0
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -36,6 +36,7 @@ provisioner:
           - sudo
         sshd_host_keys_group: ssh_keys
         sshd_update_moduli: true
+        sysctl_conf_dir: /etc/sysctl.d/
         system_upgrade: false
       bookworm:
         ansible_become_pass: vagrant
@@ -59,6 +60,7 @@ provisioner:
           - sudo
         sshd_update_moduli: true
         suid_sgid_permissions: false
+        sysctl_conf_dir: /etc/sysctl.d/
         umask_value: "027"
       jammy:
         disable_ipv6: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -42,6 +42,17 @@
           ansible.builtin.set_fact:
             crypto_policies_config: "{{ stat_crypto_policies_config.stat.exists }}"
 
+    - name: Set sysctl configuration directory as fact
+      block:
+        - name: Stat /usr/lib/sysctl.d/ exists
+          ansible.builtin.stat:
+            path: /usr/lib/sysctl.d/
+          register: usr_lib_sysctl_d
+
+        - name: Set sysctl fact
+          ansible.builtin.set_fact:
+            usr_lib_sysctl_d_dir: "{{ true if usr_lib_sysctl_d.stat.exists else false }}"
+
     - name: Ensure test groups exists
       become: true
       ansible.builtin.group:
@@ -66,16 +77,6 @@
       loop:
         - testuser01
         - testuser02
-
-    - name: Set sysctl configuration directory as fact
-      tags:
-        - fact
-        - sysctl
-      block:
-        - name: Stat /usr/lib/sysctl.d/ exists
-          ansible.builtin.stat:
-            path: /usr/lib/sysctl.d/
-          register: usr_lib_sysctl_d
 
     - name: Get installed sshd version
       environment:
@@ -458,6 +459,10 @@
         - GSSAPIAuthentication {{ 'yes' if (sshd_gssapi_authentication | bool) else 'no' }}
         - HashKnownHosts yes
         - RekeyLimit {{ sshd_rekey_limit }}
+
+    - name: Print sysctl configuration directory
+      ansible.builtin.debug:
+        msg: "{{ sysctl_conf_dir }}"
 
     - name: Merge sysctl settings
       ansible.builtin.set_fact:

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -55,7 +55,7 @@
 
     - name: Set sysctl fact
       ansible.builtin.set_fact:
-        sysctl_conf_dir: "{{ '/usr/lib/sysctl.d' if usr_lib_sysctl_d.stat.exists else '/etc/sysctl.d' }}"
+        usr_lib_sysctl_d_dir: "{{ true if usr_lib_sysctl_d.stat.exists else false }}"
 
 - name: Set crypto-policies config as fact
   block:


### PR DESCRIPTION
set `sysctl_conf_dir` as a default variable instead of fact, in order to support host vars