### PR TITLE
Configure rsyslod to not log cron messages to /var/log/syslog but to /var/log/cron.log

### DIFF
--- a/defaults/main/templates.yml
+++ b/defaults/main/templates.yml
@@ -16,10 +16,12 @@ login_defs_template: etc/login.defs.j2
 login_template: etc/pam.d/login.j2
 logind_conf_template: etc/systemd/logind.conf.j2
 logrotate_conf_template: etc/logrotate.conf.j2
+logrotate_rsyslog_conf_template: etc/logrotate/rsyslog.conf.j2
 motd_template: etc/motd.j2
 pwquality_conf_template: etc/security/pwquality.conf.j2
 resolved_conf_template: etc/systemd/resolved.conf.j2
 rkhunter_template: etc/default/rkhunter.j2
+rsyslogd_template: etc/rsyslogd/50-default.conf.j2
 ssh_config_template: etc/ssh/ssh_config.j2
 sshd_config_template: etc/ssh/sshd_config.j2
 sysctl_ipv6_config_template: etc/sysctl/sysctl.ipv6.conf.j2

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -214,3 +214,9 @@
     cmd: rsyslogd -N3 -f /etc/rsyslog.conf
   register: validate_rsyslogd
   changed_when: validate_rsyslogd.rc == 0
+
+- name: Restart rsyslogd
+  become: true
+  ansible.builtin.service:
+    name: rsyslog
+    state: restarted

--- a/tasks/cron.yml
+++ b/tasks/cron.yml
@@ -2,6 +2,29 @@
 - name: Configure scheduled command services
   become: true
   block:
+    - name: Template rsyslog.conf
+      become: true
+      ansible.builtin.template:
+        src: "{{ logrotate_rsyslog_conf_template }}"
+        dest: /etc/logrotate.d/rsyslog
+        backup: true
+        mode: "0644"
+        owner: root
+        group: root
+
+    - name: Don't send cron logs to syslog
+      become: true
+      ansible.builtin.template:
+        src: "{{ rsyslogd_template }}"
+        dest: /etc/rsyslog.d/50-default.conf
+        backup: true
+        mode: "0644"
+        owner: root
+        group: root
+      notify:
+        - Validate rsyslogd
+        - Restart rsyslogd
+
     - name: Remove cron.deny and at.deny
       ansible.builtin.file:
         path: "{{ item }}"

--- a/templates/etc/logrotate/rsyslog.conf.j2
+++ b/templates/etc/logrotate/rsyslog.conf.j2
@@ -1,0 +1,37 @@
+/var/log/syslog
+{
+        rotate 7
+        daily
+        missingok
+        notifempty
+        delaycompress
+        compress
+        postrotate
+                /usr/lib/rsyslog/rsyslog-rotate
+        endscript
+}
+
+/var/log/mail.info
+/var/log/mail.warn
+/var/log/mail.err
+/var/log/mail.log
+/var/log/daemon.log
+/var/log/kern.log
+/var/log/auth.log
+/var/log/user.log
+/var/log/lpr.log
+/var/log/cron.log
+/var/log/debug
+/var/log/messages
+{
+        rotate 4
+        weekly
+        missingok
+        notifempty
+        compress
+        delaycompress
+        sharedscripts
+        postrotate
+                /usr/lib/rsyslog/rsyslog-rotate
+        endscript
+}

--- a/templates/etc/rsyslogd/50-default.conf.j2
+++ b/templates/etc/rsyslogd/50-default.conf.j2
@@ -1,0 +1,43 @@
+#  Default rules for rsyslog.
+#
+#                       For more information see rsyslog.conf(5) and /etc/rsyslog.conf
+
+#
+# First some standard log files.  Log by facility.
+#
+auth,authpriv.*                 /var/log/auth.log
+*.*;auth,authpriv.none,cron.none          -/var/log/syslog
+cron.*                          -/var/log/cron.log
+daemon.*                       -/var/log/daemon.log
+kern.*                          -/var/log/kern.log
+lpr.*                           /var/log/lpr.log
+mail.*                          -/var/log/mail.log
+user.*                          /var/log/user.log
+
+#
+# Logging for the mail system.  Split it up so that
+# it is easy to write scripts to parse these files.
+#
+#mail.info                      -/var/log/mail.info
+mail.*                          /var/log/mail.log
+mail.err                        /var/log/mail.err
+
+#
+# Some "catch-all" log files.
+#
+#*.=debug;\
+#       auth,authpriv.none;\
+#       news.none;mail.none     -/var/log/debug
+#*.=info;*.=notice;*.=warn;\
+#       auth,authpriv.none;\
+#       cron,daemon.none;\
+#       mail,news.none          -/var/log/messages
+
+#
+# Emergencies are sent to everybody logged in.
+#
+*.emerg                         :omusrmsg:*
+
+#       news.=crit;news.=err;news.=notice;\
+#       *.=debug;*.=info;\
+#       *.=notice;*.=warn       /dev/tty8


### PR DESCRIPTION
Recently noticed on a server with a lot of cron jobs that they were spamming up /var/log/syslog, making it hard to read.

So I created an rsyslog configuration that should set it so that stops happening, and those logs only go to /var/log/cron.log.


Also set up logrotation for the most common /var/log/ files, including /var/log/cron.log