### PR TITLE
feat: Make all tasks skippable using variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ roles:
           - 10.0.2.0/24
           - 192.168.0.0/24
           - 192.168.1.0/24
-        suid_sgid_permissions: false
+        manage_suid_sgid_permissions: false
 ```
 
 ### Local playbook using git checkout
@@ -987,7 +987,7 @@ repository.
 ### ./defaults/main/suid_sgid_blocklist.yml
 
 ```yaml
-suid_sgid_permissions: true
+manage_suid_sgid_permissions: true
 suid_sgid_blocklist:
   - 7z
   - aa-exec
@@ -1002,7 +1002,7 @@ suid_sgid_blocklist:
   [...]
 ```
 
-If `suid_sgid_permissions: true` loop through `suid_sgid_blocklist` and remove
+If `manage_suid_sgid_permissions: true` loop through `suid_sgid_blocklist` and remove
 any SUID/SGID permissions.
 
 A complete file list is available in

--- a/defaults/main/adduser.yml
+++ b/defaults/main/adduser.yml
@@ -1,0 +1,2 @@
+---
+manage_adduser_conf: true

--- a/defaults/main/apparmor.yml
+++ b/defaults/main/apparmor.yml
@@ -1,0 +1,2 @@
+---
+manage_apparmor: true

--- a/defaults/main/apport.yml
+++ b/defaults/main/apport.yml
@@ -1,0 +1,2 @@
+---
+disable_apport: true

--- a/defaults/main/cron.yml
+++ b/defaults/main/cron.yml
@@ -1,0 +1,2 @@
+---
+manage_cron: true

--- a/defaults/main/ctrlaltdel.yml
+++ b/defaults/main/ctrlaltdel.yml
@@ -1,0 +1,2 @@
+---
+disable_ctrlaltdel: true

--- a/defaults/main/fstab.yml
+++ b/defaults/main/fstab.yml
@@ -1,0 +1,2 @@
+---
+manage_fstab: true

--- a/defaults/main/hosts.yml
+++ b/defaults/main/hosts.yml
@@ -1,0 +1,2 @@
+---
+manage_hosts: true

--- a/defaults/main/issue.yml
+++ b/defaults/main/issue.yml
@@ -1,0 +1,2 @@
+---
+manage_issue: true

--- a/defaults/main/journal.yml
+++ b/defaults/main/journal.yml
@@ -1,4 +1,6 @@
 ---
+manage_journal: true
+
 rsyslog_filecreatemode: "0640"
 
 journald_compress: true

--- a/defaults/main/kernel.yml
+++ b/defaults/main/kernel.yml
@@ -1,4 +1,5 @@
 ---
+manage_kernel: true
 allow_virtual_system_calls: true
 enable_page_poisoning: true
 kernel_lockdown: false

--- a/defaults/main/limits.yml
+++ b/defaults/main/limits.yml
@@ -1,4 +1,5 @@
 ---
+manage_limits: true
 limit_nofile_hard: 1024
 limit_nofile_soft: 512
 limit_nproc_hard: 1024

--- a/defaults/main/lockroot.yml
+++ b/defaults/main/lockroot.yml
@@ -1,0 +1,2 @@
+---
+disable_root_account: true

--- a/defaults/main/logind.yml
+++ b/defaults/main/logind.yml
@@ -1,4 +1,5 @@
 ---
+manage_logind: true
 logind:
   killuserprocesses: true
   killexcludeusers:

--- a/defaults/main/logindefs.yml
+++ b/defaults/main/logindefs.yml
@@ -1,0 +1,2 @@
+---
+manage_login_defs: true

--- a/defaults/main/module_blocklists.yml
+++ b/defaults/main/module_blocklists.yml
@@ -1,4 +1,6 @@
 ---
+manage_kernel_modules: true
+
 fs_modules_blocklist:
   - cramfs
   - freevxfs

--- a/defaults/main/motdnews.yml
+++ b/defaults/main/motdnews.yml
@@ -1,0 +1,2 @@
+---
+manage_motdnews: true

--- a/defaults/main/mount.yml
+++ b/defaults/main/mount.yml
@@ -1,3 +1,4 @@
 ---
+manage_mounts: true
 hide_pid: 2
 process_group: root

--- a/defaults/main/netplan.yml
+++ b/defaults/main/netplan.yml
@@ -1,0 +1,2 @@
+---
+manage_netplan: true

--- a/defaults/main/packagemgmt.yml
+++ b/defaults/main/packagemgmt.yml
@@ -1,4 +1,5 @@
 ---
+manage_package_managers: true
 apt_hardening_options:
   - Acquire::AllowDowngradeToInsecureRepositories "false";
   - Acquire::AllowInsecureRepositories "false";

--- a/defaults/main/packages.yml
+++ b/defaults/main/packages.yml
@@ -1,4 +1,5 @@
 ---
+manage_packages: true
 system_upgrade: true
 
 packages_blocklist:

--- a/defaults/main/password.yml
+++ b/defaults/main/password.yml
@@ -1,4 +1,5 @@
 ---
+manage_pam: true
 manage_faillock: true
 
 faillock:

--- a/defaults/main/path.yml
+++ b/defaults/main/path.yml
@@ -1,0 +1,2 @@
+---
+manage_path: true

--- a/defaults/main/postfix.yml
+++ b/defaults/main/postfix.yml
@@ -1,0 +1,2 @@
+---
+manage_postfix: true

--- a/defaults/main/prelink.yml
+++ b/defaults/main/prelink.yml
@@ -1,0 +1,2 @@
+---
+disable_prelink: true

--- a/defaults/main/rootaccess.yml
+++ b/defaults/main/rootaccess.yml
@@ -1,0 +1,2 @@
+---
+manage_root_access: true

--- a/defaults/main/sudo.yml
+++ b/defaults/main/sudo.yml
@@ -1,0 +1,2 @@
+---
+manage_sudo: true

--- a/defaults/main/suid_sgid_blocklist.yml
+++ b/defaults/main/suid_sgid_blocklist.yml
@@ -1,5 +1,5 @@
 ---
-suid_sgid_permissions: true
+manage_suid_sgid_permissions: true
 suid_sgid_blocklist:
   - 7z
   - aa-exec

--- a/defaults/main/systemdconf.yml
+++ b/defaults/main/systemdconf.yml
@@ -1,0 +1,2 @@
+---
+manage_systemd: true

--- a/defaults/main/umask.yml
+++ b/defaults/main/umask.yml
@@ -1,3 +1,4 @@
 ---
+manage_umask: true
 session_timeout: 900
 umask_value: "077"

--- a/defaults/main/users.yml
+++ b/defaults/main/users.yml
@@ -1,4 +1,5 @@
 ---
+manage_users: true
 delete_users:
   - games
   - gnats

--- a/genREADME.sh
+++ b/genREADME.sh
@@ -69,7 +69,7 @@ roles:
           - 10.0.2.0/24
           - 192.168.0.0/24
           - 192.168.1.0/24
-        suid_sgid_permissions: false
+        manage_suid_sgid_permissions: false
 \`\`\`
 
 ### Local playbook using git checkout

--- a/molecule/almalinux/molecule.yml
+++ b/molecule/almalinux/molecule.yml
@@ -25,7 +25,7 @@ provisioner:
         sshd_allow_groups:
           - vagrant
           - sudo
-        suid_sgid_permissions: false
+        manage_suid_sgid_permissions: false
         system_upgrade: false
 platforms:
   - name: almalinux9

--- a/molecule/custom/molecule.yml
+++ b/molecule/custom/molecule.yml
@@ -69,7 +69,7 @@ provisioner:
         pass_max_days: 365
         pass_min_days: 7
         sshd_max_sessions: 4
-        suid_sgid_permissions: false
+        manage_suid_sgid_permissions: false
         umask_value: "027"
 platforms:
   - name: jammy

--- a/molecule/debian/molecule.yml
+++ b/molecule/debian/molecule.yml
@@ -26,7 +26,7 @@ provisioner:
         sshd_allow_groups:
           - vagrant
           - sudo
-        suid_sgid_permissions: false
+        manage_suid_sgid_permissions: false
         system_upgrade: false
       bullseye:
         ansible_become_pass: vagrant
@@ -37,7 +37,7 @@ provisioner:
         sshd_allow_groups:
           - vagrant
           - sudo
-        suid_sgid_permissions: false
+        manage_suid_sgid_permissions: false
       testing:
         ansible_become_pass: vagrant
         ansible_python_interpreter: /usr/bin/python3
@@ -48,7 +48,7 @@ provisioner:
         sshd_allow_groups:
           - vagrant
           - sudo
-        suid_sgid_permissions: false
+        manage_suid_sgid_permissions: false
         sshd_update_moduli: true
 platforms:
   - name: bookworm

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -54,7 +54,7 @@ provisioner:
         sshd_allow_groups:
           - vagrant
           - sudo
-        suid_sgid_permissions: false
+        manage_suid_sgid_permissions: false
         sshd_match_users:
           - user: testuser01
             rules:
@@ -89,7 +89,7 @@ provisioner:
           - vagrant
           - sudo
         sshd_update_moduli: true
-        suid_sgid_permissions: false
+        manage_suid_sgid_permissions: false
         sysctl_conf_dir: /etc/sysctl.d/
         umask_value: "027"
         ufw_rate_limit: true

--- a/molecule/docker/molecule.yml
+++ b/molecule/docker/molecule.yml
@@ -44,7 +44,7 @@ provisioner:
         sshd_allow_groups:
           - vagrant
           - sudo
-        suid_sgid_permissions: false
+        manage_suid_sgid_permissions: false
         sshd_match_users:
           - user: testuser01
             rules:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,12 +45,16 @@
 - name: Configure kernel settings
   ansible.builtin.import_tasks:
     file: kernel.yml
+  when:
+    - manage_kernel
   tags:
     - kernel
 
 - name: Disable kernel modules
   ansible.builtin.import_tasks:
     file: kernelmodules.yml
+  when:
+    - manage_kernel_modules
   tags:
     - kernel
 
@@ -75,12 +79,16 @@
 - name: Configure systemd system and users
   ansible.builtin.import_tasks:
     file: systemdconf.yml
+  when:
+    - manage_systemd
   tags:
     - systemd
 
 - name: Configure systemd journald and logrotate
   ansible.builtin.import_tasks:
     file: journalconf.yml
+  when:
+    - manage_journal
   tags:
     - journald
     - logrotate
@@ -99,24 +107,32 @@
 - name: Clean fstab
   ansible.builtin.import_tasks:
     file: fstab.yml
+  when:
+    - manage_fstab
   tags:
     - mounts
 
 - name: Configure shm and tmp mounts
   ansible.builtin.import_tasks:
     file: mount.yml
+  when:
+    - manage_mounts
   tags:
     - mounts
 
 - name: Disable prelink
   ansible.builtin.import_tasks:
     file: prelink.yml
+  when:
+    - disable_prelink
   tags:
     - prelink
 
 - name: Configure package managers, update caches and install updates
   ansible.builtin.import_tasks:
     file: packagemgmt.yml
+  when:
+    - manage_package_managers
 
 - name: Configure automatic updates
   ansible.builtin.import_tasks:
@@ -129,6 +145,8 @@
 - name: Configure hosts.allow and hosts.deny
   ansible.builtin.import_tasks:
     file: hosts.yml
+  when:
+    - manage_hosts
   tags:
     - hosts.allow
     - hosts.deny
@@ -136,18 +154,24 @@
 - name: Configure login.defs
   ansible.builtin.import_tasks:
     file: logindefs.yml
+  when:
+    - manage_login_defs
   tags:
     - login.defs
 
 - name: Set limits
   ansible.builtin.import_tasks:
     file: limits.yml
+  when:
+    - manage_limits
   tags:
     - limits
 
 - name: Configure adduser and useradd
   ansible.builtin.import_tasks:
     file: adduser.yml
+  when:
+    - manage_adduser_conf
   tags:
     - adduser
     - useradd
@@ -155,12 +179,16 @@
 - name: Restrict root access
   ansible.builtin.import_tasks:
     file: rootaccess.yml
+  when:
+    - manage_root_access
   tags:
     - root_access
 
 - name: Configure needrestart, install and remove various packages
   ansible.builtin.import_tasks:
     file: packages.yml
+  when:
+    - manage_packages
   tags:
     - package_installation
 
@@ -175,6 +203,8 @@
 - name: Configure PAM
   ansible.builtin.import_tasks:
     file: password.yml
+  when:
+    - manage_pam
   tags:
     - cracklib
     - crypto_policy
@@ -185,6 +215,8 @@
 - name: Configure and clean at and cron
   ansible.builtin.import_tasks:
     file: cron.yml
+  when:
+    - manage_cron
   tags:
     - at
     - cron
@@ -193,6 +225,7 @@
   ansible.builtin.import_tasks:
     file: ctrlaltdel.yml
   when:
+    - disable_ctrlaltdel
     - ansible_virtualization_type not in ["container", "docker", "podman"]
   tags:
     - ctrl-alt-del
@@ -210,6 +243,7 @@
   ansible.builtin.import_tasks:
     file: apparmor.yml
   when:
+    - manage_apparmor
     - ansible_virtualization_type not in ["container", "docker", "podman"]
     - ansible_os_family == "Debian"
   tags:
@@ -239,6 +273,8 @@
 - name: Manage users
   ansible.builtin.import_tasks:
     file: users.yml
+  when:
+    - manage_users
   tags:
     - remove_users
 
@@ -246,7 +282,7 @@
   ansible.builtin.import_tasks:
     file: suid.yml
   when:
-    - suid_sgid_permissions | bool
+    - manage_suid_sgid_permissions
   tags:
     - suid_sgid_permissions
 
@@ -261,18 +297,24 @@
 - name: Set umask
   ansible.builtin.import_tasks:
     file: umask.yml
+  when:
+    - manage_umask
   tags:
     - umask
 
 - name: Configure paths
   ansible.builtin.import_tasks:
     file: path.yml
+  when:
+    - manage_path
   tags:
     - path
 
 - name: Configure systemd logind
   ansible.builtin.import_tasks:
     file: logindconf.yml
+  when:
+    - manage_logind
   tags:
     - logind
     - systemd
@@ -288,6 +330,8 @@
 - name: Add issue message
   ansible.builtin.import_tasks:
     file: issue.yml
+  when:
+    - manage_issue
   tags:
     - issue
     - issue.net
@@ -296,36 +340,48 @@
 - name: Configure apport
   ansible.builtin.import_tasks:
     file: apport.yml
+  when:
+    - disable_apport
   tags:
     - apport
 
 - name: Lock root account
   ansible.builtin.import_tasks:
     file: lockroot.yml
+  when:
+    - disable_root_account
   tags:
     - root_access
 
 - name: Configure Postfix
   ansible.builtin.import_tasks:
     file: postfix.yml
+  when:
+    - manage_postfix
   tags:
     - postfix
 
 - name: Configure motdnews
   ansible.builtin.import_tasks:
     file: motdnews.yml
+  when:
+    - manage_motdnews
   tags:
     - motd-news
 
 - name: Configure sudo
   ansible.builtin.import_tasks:
     file: sudo.yml
+  when:
+    - manage_sudo
   tags:
     - sudo
 
 - name: Set netplan permissions
   ansible.builtin.import_tasks:
     file: netplan.yml
+  when:
+    - manage_netplan
   tags:
     - netplan
 


### PR DESCRIPTION
I wanted to skip the apparmor tasks on some specific hosts but could't find a way to do that without running Ansible with `--skip-tags apparmor`. I noticed that many tasks already have a way to exclude them with `manage_xyz: false`, but not all.

So this is my attempt to add it to all tasks. All tasks now have a variable with prefix `manage_` that is `true` by default. Exception to this are tasks that just out right disable something, such as `disable_prelink` or `disable_apport`. 

Since all tasks are still `true` this should not change anything for end-users. The only real change is that I renamed `suid_sgid_permissions` to `manage_suid_sgid_permissions` to be more consistent. I'm a bit unsure if I should change `automatic_updates.enabled` to be consistent with this as well, I left it as is for now.

Also
This creates a lot of one-line files in `defaults/main` just to enable tasks, another way to do this would be to do something like:
```
when:
  manage_kernel | default(true)
```

I'm personally fine with either way, the way I did it now is a bit more welcoming to moving hardcoded lines in tasks to default vars.