### PR TITLE
mask ctrl-alt-del using FragmentPath

### DIFF
--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -194,6 +194,19 @@
         - DefaultLimitNOFILE={{ limit_nofile_hard }}
         - DefaultLimitNPROC={{ limit_nproc_hard }}
 
+    - name: Verify masked Ctrl-Alt-Del
+      become: true
+      ansible.builtin.systemd:
+        name: ctrl-alt-del.target
+        masked: true
+        enabled: false
+        state: stopped
+      check_mode: true
+      register: ctrl_alt_del_target
+      failed_when: ctrl_alt_del_target is changed
+      when:
+        - ansible_virtualization_type not in ["container", "docker", "podman"]
+
     - name: Verify systemd user.conf
       become: true
       ansible.builtin.lineinfile:

--- a/tasks/ctrlaltdel.yml
+++ b/tasks/ctrlaltdel.yml
@@ -1,21 +1,14 @@
 ---
 - name: Disable systemd ctrl-alt-del
-  become: true
   ansible.builtin.systemd:
     name: ctrl-alt-del.target
-    masked: true
-    enabled: false
-    state: stopped
-  when:
-    - not ansible_os_family == "RedHat"
+  register: ctrl_alt_del_target
 
-- name: Disable systemd ctrl-alt-del - RedHat family
+- name: Disable systemd ctrl-alt-del
   become: true
-  ansible.builtin.systemd:
-    name: ctrl-alt-del.target
-    masked: true
-    enabled: false
-    state: stopped
-  changed_when: false
-  when:
-    - ansible_os_family == "RedHat"
+  ansible.builtin.file:
+    src: /dev/null
+    path: "{{ ctrl_alt_del_target.status.FragmentPath }}"
+    state: link
+    owner: root
+    group: root


### PR DESCRIPTION
On AlmaLinux 9 the `ctrl-alt-del.target` is already a link and fails when masking.