### PR TITLE
add journald permission variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,10 @@ rsyslog_filecreatemode: "0640"
 journald_compress: true
 journald_forwardtosyslog: false
 journald_storage: persistent
+
+journald_permissions: "2640"
+journald_group: "systemd-journal"
+journald_user: "root"
 ```
 
 If `manage_journal: true`, then `journald` will be configured and
@@ -435,6 +439,14 @@ objects are compressed before they are written to the file system.
 
 `journald_forwardtosyslog` control whether log messages received by the journal
 daemon shall be forwarded to a traditional syslog daemon.
+
+`journald_permissions` sets the file permissions for the journal files and
+directories.
+
+`journald_group` and `journald_user` sets the group and user for the journal
+files and directories.
+
+Permissions, user and group are set using [tmpfiles.d](https://www.man7.org/linux/man-pages/man5/tmpfiles.d.5.html).
 
 See [journald.conf](https://www.freedesktop.org/software/systemd/man/latest/journald.conf.html)
 for more information.

--- a/defaults/main/journal.yml
+++ b/defaults/main/journal.yml
@@ -6,3 +6,7 @@ rsyslog_filecreatemode: "0640"
 journald_compress: true
 journald_forwardtosyslog: false
 journald_storage: persistent
+
+journald_permissions: "2640"
+journald_group: "systemd-journal"
+journald_user: "root"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1421,6 +1421,14 @@
     - name: Verify journal permissions
       become: true
       block:
+        - name: Verify tmpfiles settings
+          ansible.builtin.shell:
+            cmd: grep -E "^z /var/log/journal {{ journald_permissions }} {{ journald_user }} {{ journald_group }} - -$" /etc/tmpfiles.d/systemd.conf
+          register: journal_tmpfiles
+          changed_when: false
+          failed_when:
+            - journal_tmpfiles.rc != 0
+
         - name: Find journal directories
           become: true
           ansible.builtin.shell:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1428,6 +1428,8 @@
           changed_when: false
           failed_when:
             - journal_tmpfiles.rc != 0
+          when:
+            - ansible_virtualization_type not in ["container", "docker", "podman"]
 
         - name: Find journal directories
           become: true

--- a/tasks/journalconf.yml
+++ b/tasks/journalconf.yml
@@ -42,11 +42,11 @@
     group: root
     create: true
     block: |
-      z /run/log/journal 2640 root systemd-journal - -
-      Z /run/log/journal/%m ~2640 root systemd-journal - -
-      z /var/log/journal 2640 root systemd-journal - -
-      z /var/log/journal/%m 2640 root systemd-journal - -
-      z /var/log/journal/%m/system.journal 0640 root systemd-journal - -
+      Z /run/log/journal/%m ~{{ journald_permissions }} {{ journald_user }} {{ journald_group }} - -
+      z /run/log/journal {{ journald_permissions }} {{ journald_user }} {{ journald_group }} - -
+      z /var/log/journal {{ journald_permissions }} {{ journald_user }} {{ journald_group }} - -
+      z /var/log/journal/%m {{ journald_permissions }} {{ journald_user }} {{ journald_group }} - -
+      z /var/log/journal/%m/system.journal 0640 {{ journald_user }} {{ journald_group }} - -
   when:
     - tmpfiles_d.stat.exists
 


### PR DESCRIPTION
`V-260502/UBTU-22-232085` and `V-260504/UBTU-22-232095` might cause permission issues when using log shippers.