### PR TITLE
Ensure ftp client is not installed

### DIFF
--- a/defaults/main/packages.yml
+++ b/defaults/main/packages.yml
@@ -7,6 +7,7 @@ packages_blocklist:
   - avahi*
   - avahi-*
   - beep
+  - ftp
   - git
   - pastebinit
   - popularity-contest
@@ -17,6 +18,7 @@ packages_blocklist:
   - talk*
   - telnet*
   - tftp*
+  - tnftp
   - tuned
   - whoopsie
   - xinetd


### PR DESCRIPTION
CIS Ubuntu Linux 24.04 LTS: 2.2.6 Ensure ftp client is not installed