### PR TITLE
Simplify unattended-upgrades configuration (#918)

### DIFF
--- a/templates/etc/apt/apt.conf.d/52unattended-upgrades-local.j2
+++ b/templates/etc/apt/apt.conf.d/52unattended-upgrades-local.j2
@@ -1,31 +1,18 @@
+{% if not automatic_updates.only_security %}
 {% if ansible_distribution == "Ubuntu" %}
 Unattended-Upgrade::Allowed-Origins {
-        "${distro_id}:${distro_codename}";
-        "${distro_id}:${distro_codename}-security";
-        {% if not automatic_updates.only_security %}
         "${distro_id}:${distro_codename}-updates";
-        {% endif %}
-        "${distro_id}ESMApps:${distro_codename}-apps-security";
-        "${distro_id}ESM:${distro_codename}-infra-security";
 };
-
-Unattended-Upgrade::DevRelease "auto";
-{% else %}
+{% elif ansible_distribution == "Debian" %}
 Unattended-Upgrade::Origins-Pattern {
-        "origin=Debian,codename=${distro_codename},label=Debian";
-        "origin=Debian,codename=${distro_codename},label=Debian-Security";
-        "origin=Debian,codename=${distro_codename}-security,label=Debian-Security";
+        "origin=Debian,codename=${distro_codename}-updates";
 };
 {% endif %}
-
-Unattended-Upgrade::Package-Blacklist {
-};
+{% endif %}
 
 {% if automatic_updates.reboot %}
 Unattended-Upgrade::Automatic-Reboot "true";
 Unattended-Upgrade::Automatic-Reboot-Time "{{ '%02d:%02d'|format((reboot_hour | int), (reboot_minute | int)) }}";
-{% else %}
-Unattended-Upgrade::Automatic-Reboot "false";
 {% endif %}
 Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
 Unattended-Upgrade::Remove-New-Unused-Dependencies "true";


### PR DESCRIPTION
Implements https://github.com/konstruktoid/ansible-role-hardening/issues/918#issuecomment-3066841662.

I've removed the defaults for `Unattended-Upgrade::DevRelease`, `Unattended-Upgrade::Package-Blacklist`, and `Unattended-Upgrade::Automatic-Reboot`, since they are already present in [50unattended-upgrades.Ubuntu](https://github.com/mvo5/unattended-upgrades/blob/master/data/50unattended-upgrades.Ubuntu) and [50unattended-upgrades.Debian](https://github.com/mvo5/unattended-upgrades/blob/master/data/50unattended-upgrades.Debian).

Configuration can be checked by running `apt-config dump`. It should output e.g. on Ubuntu:
```
Unattended-Upgrade "";
Unattended-Upgrade::Allowed-Origins "";
Unattended-Upgrade::Allowed-Origins:: "${distro_id}:${distro_codename}";
Unattended-Upgrade::Allowed-Origins:: "${distro_id}:${distro_codename}-security";
Unattended-Upgrade::Allowed-Origins:: "${distro_id}ESMApps:${distro_codename}-apps-security";
Unattended-Upgrade::Allowed-Origins:: "${distro_id}ESM:${distro_codename}-infra-security";
Unattended-Upgrade::Allowed-Origins:: "${distro_id}:${distro_codename}-updates";
```
Security updates origins ought to be picked from the defaults: https://github.com/mvo5/unattended-upgrades/blob/master/data/50unattended-upgrades.Ubuntu#L6.

[The sources](https://github.com/mvo5/unattended-upgrades/tree/master/data) have separate configurations for Devuan and Raspbian, but they aren't supported by this project anyway.