### PR TITLE
Added custom_origins for automatic_updates

### DIFF
--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -1472,6 +1472,7 @@ argument_specs:
           - reboot: false
           - reboot_from_time: "2:00"
           - reboot_time_margin_mins: 20
+          - custom_origins: ''
         description: "Configure automatic updates."
         options:
           enabled:
@@ -1489,6 +1490,19 @@ argument_specs:
           reboot_time_margin_mins:
             description: "Add minutes to the reboot time, set using C(reboot_from_time)."
             type: "int"
+          custom_origins:
+            description: "Add custom origins to unattended upgrades like e.g. Docker"
+            type: "dict"
+            options:
+              name:
+                description: "Add name as description to 52-unattended-upgrade-local with // prefix. // Docker repository - e.g. Docker repository"
+                type: "str"
+              origin:
+                description: "Origin - can be found with apt-cache policy o=Docker - e.g. Docker"
+                type: "str"
+              archive:
+                description: "Archive - can be found with apt-cache policy a=bookworm - e.g. bookworm"
+                type: "str"
       manage_netplan:
         description: "If True, then any available netplan configuration files will have the permissions set to 0600."
         type: "bool"

--- a/templates/etc/apt/apt.conf.d/52unattended-upgrades-local.j2
+++ b/templates/etc/apt/apt.conf.d/52unattended-upgrades-local.j2
@@ -2,10 +2,10 @@
 {% if ansible_distribution == "Ubuntu" %}
 Unattended-Upgrade::Allowed-Origins {
         "${distro_id}:${distro_codename}-updates";
-	      {% for origin in automatic_updates.custom_origins -%}
-	      // {{ origin.name}}
+	{% for origin in automatic_updates.custom_origins -%}
+	// {{ origin.name}}
         "{{ origin.origin }}:{{ origin.archive }}";
-	      {% endfor -%}
+	{% endfor -%}
 };
 {% elif ansible_distribution == "Debian" %}
 Unattended-Upgrade::Origins-Pattern {
@@ -13,7 +13,7 @@ Unattended-Upgrade::Origins-Pattern {
         {% for origin in automatic_updates.custom_origins -%}
         // {{ origin.name }}
         "origin={{ origin.origin }},archive={{ origin.archive }}";
-	      {% endfor -%}
+	{% endfor -%}
 };
 {% endif %}
 {% endif %}

--- a/templates/etc/apt/apt.conf.d/52unattended-upgrades-local.j2
+++ b/templates/etc/apt/apt.conf.d/52unattended-upgrades-local.j2
@@ -7,6 +7,10 @@ Unattended-Upgrade::Allowed-Origins {
         {% endif %}
         "${distro_id}ESMApps:${distro_codename}-apps-security";
         "${distro_id}ESM:${distro_codename}-infra-security";
+	{% for origin in automatic_updates.custom_origins -%}
+	// {{ origin.name}}
+        "{{ origin.origin }}:{{ origin.archive }}";
+	{% endfor -%}
 };
 
 Unattended-Upgrade::DevRelease "auto";
@@ -15,6 +19,10 @@ Unattended-Upgrade::Origins-Pattern {
         "origin=Debian,codename=${distro_codename},label=Debian";
         "origin=Debian,codename=${distro_codename},label=Debian-Security";
         "origin=Debian,codename=${distro_codename}-security,label=Debian-Security";
+	{% for origin in automatic_updates.custom_origins -%}
+	// {{ origin.name }}
+        "origin={{ origin.origin }},archive={{ origin.archive }}";
+	{% endfor -%}
 };
 {% endif %}
 


### PR DESCRIPTION
Tried to add the correct values in `argument_specs.yml`

Actually i decided to go the way of customizing both sections for Ubuntu and Debian mentioned by @nihil-admirari in #918. 

I wonder if it could be a better way to go with an extra `53unattended-upgrades-custom-origins` file? At the end all origins would be merged anyway.  So it would be possible to clean up the code like the example @nihil-admirari in #918 with a single section. The caveheat would be a another file which could confuse people not familiar with unattended-upgrades. 