### PR TITLE
perf(kernelmodules): Optimize blacklisted kernel modules task

### DIFF
--- a/tasks/kernelmodules.yml
+++ b/tasks/kernelmodules.yml
@@ -63,13 +63,14 @@
 
 - name: Block blacklisted kernel modules
   become: true
-  ansible.builtin.lineinfile:
+  ansible.builtin.copy:
+    content: |
+      # Blacklisted kernel modules - ansible managed
+      {% for module in modprobe_blacklist.stdout_lines | sort | unique %}
+      install {{ module }} /bin/true
+      {% endfor %}
     dest: /etc/modprobe.d/blacklist-blocked.conf
-    line: install {{ item }} /bin/true
     mode: "0644"
     owner: root
     group: root
-    state: present
-    create: true
-  with_items:
-    - "{{ modprobe_blacklist.stdout_lines | sort | unique }}"
+    backup: true


### PR DESCRIPTION
Replace inefficient lineinfile loop with copy module using Jinja2 template.

The previous implementation used `lineinfile` in a loop over ~233 kernel modules, making the task very slow.

The new implementation uses the copy module with templated content.