### PR TITLE
Changing the example use of the ansible galaxy role of this project from "import_role" to "include_role".

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ roles:
   any_errors_fatal: true
   tasks:
     - name: Import the hardening role
-      ansible.builtin.import_role:
+      ansible.builtin.include_role:
         name: konstruktoid.hardening
       vars:
         kernel_lockdown: true

--- a/generate_doc_defaults.sh
+++ b/generate_doc_defaults.sh
@@ -67,7 +67,7 @@ roles:
   any_errors_fatal: true
   tasks:
     - name: Import the hardening role
-      ansible.builtin.import_role:
+      ansible.builtin.include_role:
         name: konstruktoid.hardening
       vars:
         kernel_lockdown: true

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,5 +6,5 @@
     crypto_policy: "DEFAULT"
   tasks:
     - name: Import role
-      ansible.builtin.import_role:
+      ansible.builtin.include_role:
         name: konstruktoid.hardening


### PR DESCRIPTION
This is because "import_role" ignores override of variables like "manage_ufw", where "include_role" does not.

This was already being done in the "Local playbook using git checkout" example in the readme.

I ran into this when setting up a test setup like this:

```
- name: Import and use the hardening role
  hosts: all
  any_errors_fatal: true
  tasks:
    - name: Import the hardening role
      ansible.builtin.import_role:
        name: konstruktoid.hardening
      vars:
        manage_resolved: true
        manage_ufw: false
```

And it started executing the UFW role anyway.

Changing `import_role` to `include_role` made it skip that, though ansible will still print all the steps, just not execute them.