### PR TITLE
Added a variable "manage_umask", similar to other "manage_..." variables in the main.yml file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ See [TESTING.md](TESTING.md).
 | grub_audit_cmdline | Enable auditd in the GRUB command line. | audit=1 |
 | manage_systemd | If True, then the role will configure /etc/systemd/system.conf and /etc/systemd/user.conf using the available templates. | True |
 | session_timeout | Sets, in seconds, the TMOUT environment variable if systemd version is 252 or lower. If version 252 or higher, the session_timeout value will be set as StopIdleSessionSec. | 900 |
+| manage_umask | If True, set the default umask value of the system to the value of the variable "umask_value" | True |
 | umask_value | Sets the default umask value. | 0077 |
 | manage_kernel | If True, then additional kernel settings will be configured. | True |
 | allow_virtual_system_calls | Allow virtual system calls (vsyscall). | True |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -439,6 +439,9 @@ manage_timesyncd: true
 # If True, manage C(UFW) installation and configuration.
 manage_ufw: true
 
+# If True, set the default umask value of the system to the value of the variable  "umask_value"
+manage_umask: true
+
 # If True, manage C(USBGuard) installation and configuration.
 manage_usbguard: true
 

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -1770,6 +1770,10 @@ argument_specs:
           be set as StopIdleSessionSec."
         type: "int"
         default: 900
+      manage_umask:
+        description: "If True, set the default umask value of the system to the value of the variable  \"umask_value\""
+        type: "bool"
+        default: "True"
       umask_value:
         description: "Sets the default umask value."
         type: "int"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -140,6 +140,7 @@
         success_msg: "{{ home_dir.stat.path }} has correct permissions: {{ home_dir.stat.mode }}"
         fail_msg: "{{ home_dir.stat.path }} permissions are incorrect: {{ home_dir.stat.mode }}, expected {{ login_defs.home_mode }} or {{ umask_calc }}"
       when:
+        - manage_umask
         - home_dir.stat.exists
 
     - name: Get installed sshd version

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -295,6 +295,8 @@
 - name: Set umask
   ansible.builtin.import_tasks:
     file: umask.yml
+  when:
+    - manage_umask
   tags:
     - umask
 


### PR DESCRIPTION
This controls if the umask task gets executed or not, similar to other "manage_..." variables being gatekeepers for their respective tasks.

I noticed there was no "manage_..." variable for the umask playbook, when going over the main.yml file.

I looked around for where other such variables are used and mentioned, and added similar code and descriptions there. I don't know if any of that is automatic, feel free to let me know if something needs to be changed.