### PR TITLE
Added the last 2 instructions of the sudo task list, to set up the sugroup, to the block statement, thus putting it under the "manage_sudo" variable.

### DIFF
--- a/tasks/sudo.yml
+++ b/tasks/sudo.yml
@@ -113,17 +113,15 @@
       when:
         - not sudo_rs_present
 
-- name: Create su group sugroup
-  become: true
-  ansible.builtin.group:
-    name: sugroup
-    state: present
+    - name: Create su group sugroup
+      ansible.builtin.group:
+        name: sugroup
+        state: present
 
-- name: Configure su group
-  become: true
-  ansible.builtin.lineinfile:
-    line: auth required pam_wheel.so use_uid group=sugroup
-    dest: /etc/pam.d/su
-    mode: "0644"
-    state: present
-    create: true
+    - name: Configure su group
+      ansible.builtin.lineinfile:
+        line: auth required pam_wheel.so use_uid group=sugroup
+        dest: /etc/pam.d/su
+        mode: "0644"
+        state: present
+        create: true


### PR DESCRIPTION
It would be weird disabling the sudo task, and then those last 2 items get executed anyway and suddenly my machines' `su` behavior has changed.

Could be there was a good reason for this that I'm not aware of, of course.