### PR TITLE
move notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Ansible Role for Server Hardening
 
+> **Note**
+> This role has been migrated to the
+> [ansible-collection-hardening](https://github.com/konstruktoid/ansible-collection-hardening)
+> collection, and switching to that is recommended for continued updates and support.
+
 This is an [Ansible](https://www.ansible.com/) role designed to enhance the
 security of servers running on AlmaLinux, Debian, or Ubuntu.
 
@@ -35,12 +40,6 @@ this Ansible role is used for configuration.
 > and [meta/argument_specs.yml](meta/argument_specs.yml).
 > `ansible-doc -t role` can be used to view the documentation for this role as
 > well.
-
-> **Note**
-> This role has been migrated to the
-> [ansible-collection-hardening](https://github.com/konstruktoid/ansible-collection-hardening)
-> collection, and switching to that is recommended for continued updates and support.
-
 
 ## Examples
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README’s introductory section to note that the role has migrated to the `ansible-collection-hardening` collection.
  - Recommends switching to the collection for continued updates and support.
  - Removed the duplicate migration note from its previous location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->